### PR TITLE
Add automatic code style checking using vera++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ sudo: required
 dist: trusty
 language: cpp
 
+before_install:
+    - sudo apt-get install vera++
+
 script:
     - ./bin/checkStyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# Travis CI setup for OpenFOAM
+# Code style is checked only, since build times exceed Travis limits
+
+sudo: required
+dist: trusty
+language: cpp
+
+script:
+    - ./bin/checkStyle

--- a/bin/checkStyle
+++ b/bin/checkStyle
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Check code style using vera++
+# https://bitbucket.org/verateam/vera/wiki
+
+echo "Running code style check"
+
+find . -path "*lnInclude*" -prune -o \( -name "*.C" -or -name "*.H" \) -print | vera++ -s -e -P max-line-length=80 --root ./etc/vera++ -S "$@"

--- a/etc/vera++/profiles/default
+++ b/etc/vera++/profiles/default
@@ -1,0 +1,27 @@
+# This file defines the set of scripts (rules) that should be executed
+
+set rules {
+    F001
+    L001
+    L002
+    L003
+    L004
+    L005
+    T001
+    T002
+    T003
+    T004
+    T005
+    T006
+    T007
+    T008
+    T009
+    T010
+    T011
+    T012
+    T013
+    T015
+    T017
+    T018
+    T019
+}

--- a/etc/vera++/scripts/rules/F001.tcl
+++ b/etc/vera++/scripts/rules/F001.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/tclsh
+# Source files should not use the '\r' (CR) character
+
+foreach fileName [getSourceFileNames] {
+    if { $fileName == "-" } {
+      # can't check the content from stdin
+      continue
+    }
+    set file [open $fileName "r"]
+    fconfigure $file -translation lf
+    set line [gets $file]
+    set lineCounter 1
+    while {![eof $file]} {
+        set pos [string first "\r" $line]
+        if {$pos != -1 && $pos != [expr [string length $line] - 1]} {
+            report $fileName $lineCounter "\\r (CR) detected in isolation at position ${pos}"
+        }
+        set line [gets $file]
+        incr lineCounter
+    }
+    close $file
+}

--- a/etc/vera++/scripts/rules/F002.tcl
+++ b/etc/vera++/scripts/rules/F002.tcl
@@ -1,0 +1,56 @@
+#!/usr/bin/tclsh
+# File names should be well-formed
+
+set maxDirectoryDepth [getParameter "max-directory-depth" 8]
+set maxDirnameLength [getParameter "max-dirname-length" 31]
+set maxFilenameLength [getParameter "max-filename-length" 31]
+set maxPathLength [getParameter "max-path-length" 100]
+
+foreach fileName [getSourceFileNames] {
+    if {[string length $fileName] > $maxPathLength} {
+        report $fileName 1 "path name too long"
+    }
+
+    set dirDepth 0
+    foreach dir [file split [file dirname $fileName]] {
+        if {$dir == "/" || $dir == "." || $dir == ".."} {
+            continue
+        }
+
+        incr dirDepth
+
+        if {[string length $dir] > $maxDirnameLength} {
+            report $fileName 1 "directory name component too long"
+            break
+        }
+
+        set first [string index $dir 0]
+        if {[string is alpha $first] == 0 && $first != "_"} {
+            report $fileName 1 "directory name should start with alphabetic character or underscore"
+            break
+        }
+
+        if {[string first "." $dir] != -1} {
+            report $fileName 1 "directory name should not contain a dot"
+            break
+        }
+    }
+
+    if {$dirDepth >= $maxDirectoryDepth} {
+        report $fileName 1 "directory structure too deep"
+    }
+
+    set leafName [file tail $fileName]
+    if {[string length $leafName] > $maxFilenameLength} {
+        report $fileName 1 "file name too long"
+    }
+
+    set first [string index $leafName 0]
+    if {[string is alpha $first] == 0 && $first != "_"} {
+        report $fileName 1 "file name should start with alphabetic character or underscore"
+    }
+
+    if {[llength [split $leafName .]] > 2} {
+        report $fileName 1 "file name should not contain more than one dot"
+    }
+}

--- a/etc/vera++/scripts/rules/L001.tcl
+++ b/etc/vera++/scripts/rules/L001.tcl
@@ -1,0 +1,24 @@
+#!/usr/bin/tclsh
+# No trailing whitespace
+
+set strictMode [getParameter "strict-trailing-space" 0]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    set previousIndent ""
+    foreach line [getAllLines $f] {
+
+        if [regexp {^.*\r$} $line] {
+          report $f $lineNumber "CRLF line ending"
+          set line [string range $line 0 end-1]
+        }
+        if [regexp {^.*[[:space:]]+$} $line] {
+            if {$strictMode || [string trim $line] != "" || $line != $previousIndent} {
+                report $f $lineNumber "trailing whitespace"
+            }
+        }
+
+        regexp {^([[:space:]]*).*$} $line dummy previousIndent
+        incr lineNumber
+    }
+}

--- a/etc/vera++/scripts/rules/L002.tcl
+++ b/etc/vera++/scripts/rules/L002.tcl
@@ -1,0 +1,14 @@
+#!/usr/bin/tclsh
+# Don't use tab characters
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    foreach line [getAllLines $f] {
+
+        if [regexp {\t} $line] {
+            report $f $lineNumber "horizontal tab used"
+        }
+
+        incr lineNumber
+    }
+}

--- a/etc/vera++/scripts/rules/L003.tcl
+++ b/etc/vera++/scripts/rules/L003.tcl
@@ -1,0 +1,17 @@
+#!/usr/bin/tclsh
+# No leading and no trailing empty lines
+
+foreach f [getSourceFileNames] {
+    set lineCount [getLineCount $f]
+    if {$lineCount > 0} {
+        set firstLine [getLine $f 1]
+        if {[string trim $firstLine] == ""} {
+            report $f 1 "leading empty line(s)"
+        }
+
+        set lastLine [getLine $f $lineCount]
+        if {[string trim $lastLine] == ""} {
+            report $f $lineCount "trailing empty line(s)"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/L004.tcl
+++ b/etc/vera++/scripts/rules/L004.tcl
@@ -1,0 +1,14 @@
+#!/usr/bin/tclsh
+# Line cannot be too long
+
+set maxLength [getParameter "max-line-length" 100]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    foreach line [getAllLines $f] {
+        if {[string length $line] > $maxLength} {
+            report $f $lineNumber "line is longer than ${maxLength} characters"
+        }
+        incr lineNumber
+    }
+}

--- a/etc/vera++/scripts/rules/L005.tcl
+++ b/etc/vera++/scripts/rules/L005.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# There should not be too many consecutive empty lines
+
+set maxEmptyLines [getParameter "max-consecutive-empty-lines" 2]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    set emptyCount 0
+    set reported false
+    foreach line [getAllLines $f] {
+        if {[string trim $line] == ""} {
+            incr emptyCount
+            if {$emptyCount > $maxEmptyLines && $reported == "false"} {
+                report $f $lineNumber "too many consecutive empty lines"
+                set reported true
+            }
+        } else {
+            set emptyCount 0
+            set reported false
+        }
+        incr lineNumber
+    }
+}

--- a/etc/vera++/scripts/rules/L006.tcl
+++ b/etc/vera++/scripts/rules/L006.tcl
@@ -1,0 +1,11 @@
+#!/usr/bin/tclsh
+# Source file should not be too long
+
+set maxLines [getParameter "max-file-length" 2000]
+
+foreach f [getSourceFileNames] {
+    set length [getLineCount $f]
+    if {$length > $maxLines} {
+        report $f $length "source file is too long"
+    }
+}

--- a/etc/vera++/scripts/rules/T001.tcl
+++ b/etc/vera++/scripts/rules/T001.tcl
@@ -1,0 +1,13 @@
+#!/usr/bin/tclsh
+# One-line comments should not have forced continuation
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {cppcomment}] {
+        set lineNumber [lindex $t 1]
+        set wholeLine [getLine $f $lineNumber]
+
+        if {[string index $wholeLine end] == "\\"} {
+            report $f $lineNumber "line-continuation in one-line comment"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T002.tcl
+++ b/etc/vera++/scripts/rules/T002.tcl
@@ -1,0 +1,99 @@
+#!/usr/bin/tclsh
+# Reserved names should not be used for preprocessor macros
+
+set keywords {
+    asm
+    auto
+    bool
+    break
+    case
+    catch
+    char
+    class
+    const
+    const_cast
+    continue
+    default
+    delete
+    goto
+    do
+    double
+    dynamic_cast
+    else
+    enum
+    explicit
+    export
+    extern
+    false
+    float
+    for
+    friend
+    if
+    inline
+    int
+    long
+    mutable
+    namespace
+    new
+    operator
+    private
+    protected
+    public
+    register
+    reinterpret_cast
+    return
+    short
+    signed
+    sizeof
+    static
+    static_cast
+    struct
+    switch
+    template
+    this
+    throw
+    true
+    try
+    typedef
+    typeid
+    typename
+    union
+    unsigned
+    using
+    virtual
+    void
+    volatile
+    wchar_t
+    while
+
+    and
+    and_eq
+    bitand
+    bitor
+    compl
+    not
+    not_eq
+    or
+    or_eq
+    xor
+    xor_eq
+}
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {pp_define}] {
+        set lineNumber [lindex $t 1]
+
+        set line [getLine $f $lineNumber]
+        set rest [string trimleft [string range $line \
+                                       [expr [lindex $t 2] + [string length [lindex $t 0]]] end]]
+        set macroName [string range $rest 0 [expr [string wordend $rest 0] - 1]]
+
+        if {([regexp {^_} $macroName] && [string is upper -strict [string index $macroName 1]]) ||
+            [string first "__" $macroName] != -1} {
+            report $f $lineNumber "reserved name used for macro (incorrect use of underscore)"
+        }
+        if {[lsearch $keywords $macroName] != -1} {
+            report $f $lineNumber "reserved name used for macro (keyword or alternative token redefined)"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T003.tcl
+++ b/etc/vera++/scripts/rules/T003.tcl
@@ -1,0 +1,48 @@
+#!/usr/bin/tclsh
+# Some keywords should be followed by a single space
+
+set keywords {
+    case
+    class
+    delete
+    enum
+    explicit
+    extern
+    goto
+    new
+    struct
+    union
+    using
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+set state "other"
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$state == "keyword"} {
+            if {$tokenName == "space" && $tokenValue == " "} {
+                set state "space"
+            } else {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+                set state "other"
+            }
+        } elseif {$state == "space"} {
+            if {$tokenName == "newline"} {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+            }
+            set state "other"
+        } else {
+            if [isKeyword $tokenName] {
+                set state "keyword"
+                set lineNumber [lindex $t 1]
+                set keywordValue [lindex $t 0]
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T004.tcl
+++ b/etc/vera++/scripts/rules/T004.tcl
@@ -1,0 +1,51 @@
+#!/usr/bin/tclsh
+# Some keywords should be immediately followed by a colon
+
+set keywords {
+    default
+    private
+    protected
+    public
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+foreach f [getSourceFileNames] {
+    set lastKeywordLine 0
+    set lastKeywordColumn 0
+    set lastKeywordValue ""
+    set last ""
+    foreach t [getTokens $f 1 0 -1 -1 [concat $keywords colon]] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$tokenName == "colon"} {
+            if {$last == "keyword" && $lastKeywordLine != 0} {
+                set line [lindex $t 1]
+                set column [lindex $t 2]
+                if {$line != $lastKeywordLine ||
+                    $column != [expr $lastKeywordColumn + [string length $lastKeywordValue]]} {
+                    set nonWhiteFound "false"
+                    foreach tb [getTokens $f $lastKeywordLine [expr $lastKeywordColumn + 1] $line $column {}] {
+                        set tbName [lindex $tb 3]
+                        if {[lsearch {space newline ccomment cppcomment} $tbName] == -1} {
+                            set nonWhiteFound "true"
+                            break
+                        }
+                    }
+                    if {$nonWhiteFound == "false"} {
+                        report $f $line "colon not immediately after the \'$lastKeywordValue\' keyword"
+                    }
+                }
+            }
+            set last "colon"
+        } else {
+            set lastKeywordLine [lindex $t 1]
+            set lastKeywordColumn [lindex $t 2]
+            set lastKeywordValue $tokenValue
+            set last "keyword"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T005.tcl
+++ b/etc/vera++/scripts/rules/T005.tcl
@@ -1,0 +1,19 @@
+#!/usr/bin/tclsh
+# Keywords break and continue should be immediately followed by a semicolon
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {break continue}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set semicolons [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] 0 {semicolon}]
+        if {$semicolons == {}} {
+            report $f $line "keyword '${keyword}' not immediately followed by a semicolon"
+        } else {
+            set semColumn [lindex [lindex $semicolons 0] 2]
+            if {$semColumn != $column + [string length $keyword]} {
+                report $f $line "keyword '${keyword}' not immediately followed by a semicolon"
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T006.tcl
+++ b/etc/vera++/scripts/rules/T006.tcl
@@ -1,0 +1,21 @@
+#!/usr/bin/tclsh
+# Keywords return and throw should be immediately followed by a semicolon or a single space
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {return throw}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set followingTokens [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] 0 {}]
+        if {$followingTokens == {}} {
+            report $f $line "keyword '${keyword}' not immediately followed by a semicolon or a single space"
+        } else {
+            set first [lindex [lindex $followingTokens 0] 0]
+            if {$first != ";" && $first != " "} {
+                if {!([llength $followingTokens] >= 2 && $keyword == "throw" && $first == "(" && [lindex [lindex $followingTokens 1] 0] == ")")} {
+                    report $f $line "keyword '${keyword}' not immediately followed by a semicolon or a single space"
+                }
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T007.tcl
+++ b/etc/vera++/scripts/rules/T007.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/tclsh
+# Semicolons should not be isolated by spaces or comments from the rest of the code
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {semicolon}] {
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set previousTokens [getTokens $f $line 0 $line $column {}]
+        if {$previousTokens == {}} {
+            report $f $line "semicolon is isolated from other tokens"
+        } else {
+            set lastToken [lindex $previousTokens end]
+            set lastName [lindex $lastToken 3]
+            if {[lsearch {space ccomment} $lastName] != -1} {
+                set forTokens [getTokens $f $line 0 $line $column {for leftparen}]
+                if {[list [lindex [lindex $forTokens 0] 3] [lindex [lindex $forTokens 1] 3]] != {for leftparen}} {
+                    report $f $line "semicolon is isolated from other tokens"
+                }
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T008.tcl
+++ b/etc/vera++/scripts/rules/T008.tcl
@@ -1,0 +1,27 @@
+#!/usr/bin/tclsh
+# Keywords catch, for, if and while should be followed by a single space or
+# a new line
+
+foreach f [getSourceFileNames] {
+    set pp_pragma_line -1
+    foreach t [getTokens $f 1 0 -1 -1 {catch for if switch while pp_pragma}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set type [lindex $t 3]
+        if {$type == "pp_pragma"} {
+          set pp_pragma_line $line
+        } elseif {$pp_pragma_line != $line} {
+            set followingTokens [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] -1 {}]
+            if {[llength $followingTokens] < 2 & [lindex $followingTokens -1] != "newline"} {
+                if {[lindex [lindex $followingTokens 0] 3] != "newline"} {
+                    report $f $line "keyword '${keyword}' not followed by a single space or new line"
+                }
+            } else {
+                if {[list [lindex [lindex $followingTokens 0] 0] [lindex [lindex $followingTokens 1] 0]] != [list " " "("]} {
+                    report $f $line "keyword '${keyword}' not followed by a single space or new line"
+                }
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T009.tcl
+++ b/etc/vera++/scripts/rules/T009.tcl
@@ -1,0 +1,26 @@
+#!/usr/bin/tclsh
+# Comma should not be preceded by whitespace, but should be followed by one
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {comma}] {
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set preceding [getTokens $f $line 0 $line $column {}]
+        if {$preceding == {}} {
+            report $f $line "comma should not be preceded by whitespace"
+        } else {
+            set lastPreceding [lindex [lindex $preceding end] 3]
+            if {$lastPreceding == "space"} {
+                report $f $line "comma should not be preceded by whitespace"
+            }
+        }
+        set following [getTokens $f $line [expr $column + 1] [expr $line + 1] -1 {}]
+        if {$following != {}} {
+            set firstFollowing [lindex [lindex $following 0] 3]
+            if {$firstFollowing != "space" && $firstFollowing != "newline" &&
+                !($lastPreceding == "operator" && $firstFollowing == "leftparen")} {
+                report $f $line "comma should be followed by whitespace"
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T010.tcl
+++ b/etc/vera++/scripts/rules/T010.tcl
@@ -1,0 +1,11 @@
+#!/usr/bin/tclsh
+# Identifiers should not be composed of 'l' and 'O' characters only
+
+foreach file [getSourceFileNames] {
+    foreach t [getTokens $file 1 0 -1 -1 {identifier}] {
+        set value [lindex $t 0]
+        if [regexp {^(l|O)+$} $value] {
+            report $file [lindex $t 1] "identifier should not be composed of only 'l' and 'O'"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T011.tcl
+++ b/etc/vera++/scripts/rules/T011.tcl
@@ -1,0 +1,51 @@
+#!/usr/bin/tclsh
+# Curly brackets from the same pair should be either in the same line or in the same column
+
+proc acceptPairs {} {
+    global file parens index end
+
+    while {$index != $end} {
+        set nextToken [lindex $parens $index]
+        set tokenValue [lindex $nextToken 0]
+
+        if {$tokenValue == "\{"} {
+            incr index
+            set leftParenLine [lindex $nextToken 1]
+            set leftParenColumn [lindex $nextToken 2]
+
+            acceptPairs
+
+            if {$index == $end} {
+                report $file $leftParenLine "opening curly bracket is not closed"
+                return
+            }
+
+            set nextToken [lindex $parens $index]
+            incr index
+            set tokenValue [lindex $nextToken 0]
+            set rightParenLine [lindex $nextToken 1]
+            set rightParenColumn [lindex $nextToken 2]
+
+            if {($leftParenLine != $rightParenLine) && ($leftParenColumn != $rightParenColumn)} {
+                # make an exception for line continuation
+                set leftLine [getLine $file $leftParenLine]
+                set rightLine [getLine $file $rightParenLine]
+                if {[string index $leftLine end] != "\\" && [string index $rightLine end] != "\\"} {
+                    report $file $rightParenLine "closing curly bracket not in the same line or column"
+                }
+            }
+        } else {
+            return
+        }
+    }
+}
+
+foreach file [getSourceFileNames] {
+    set parens [getTokens $file 1 0 -1 -1 {leftbrace rightbrace}]
+    set index 0
+    set end [llength $parens]
+    acceptPairs
+    if {$index != $end} {
+        report $file [lindex [lindex $parens $index] 1] "excessive closing bracket?"
+    }
+}

--- a/etc/vera++/scripts/rules/T012.tcl
+++ b/etc/vera++/scripts/rules/T012.tcl
@@ -1,0 +1,12 @@
+#!/usr/bin/tclsh
+# Negation operator should not be used in its short form
+
+foreach file [getSourceFileNames] {
+    foreach negation [getTokens $file 1 0 -1 -1 {not}] {
+        set value [lindex $negation 0]
+        if {$value == "!"} {
+            set lineNumber [lindex $negation 1]
+            report $file $lineNumber "negation operator used in its short form"
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T013.tcl
+++ b/etc/vera++/scripts/rules/T013.tcl
@@ -1,0 +1,16 @@
+#!/usr/bin/tclsh
+# Source files should contain the copyright notice
+
+foreach file [getSourceFileNames] {
+    set found false
+    foreach comment [getTokens $file 1 0 -1 -1 {ccomment cppcomment}] {
+        set value [lindex $comment 0]
+        if {[string first "copyright" [string tolower $value]] != -1} {
+            set found true
+            break
+        }
+    }
+    if {$found == false} {
+        report $file 1 "no copyright notice found"
+    }
+}

--- a/etc/vera++/scripts/rules/T014.tcl
+++ b/etc/vera++/scripts/rules/T014.tcl
@@ -1,0 +1,16 @@
+#!/usr/bin/tclsh
+# Source files should refer the Boost Software License
+
+foreach file [getSourceFileNames] {
+    set found false
+    foreach comment [getTokens $file 1 0 -1 -1 {ccomment cppcomment}] {
+        set value [lindex $comment 0]
+        if {[string first "Boost Software License" $value] != -1} {
+            set found true
+            break
+        }
+    }
+    if {$found == false} {
+        report $file 1 "no reference to the Boost Software License found"
+    }
+}

--- a/etc/vera++/scripts/rules/T015.tcl
+++ b/etc/vera++/scripts/rules/T015.tcl
@@ -1,0 +1,49 @@
+#!/usr/bin/tclsh
+# HTML links in comments and string literals should be correct
+
+set urlRe {<[[:space:]]*[^>]*[[:space:]]+(?:HREF|SRC)[[:space:]]*=[[:space:]]*\"([^\"]*)\"}
+
+foreach file [getSourceFileNames] {
+    foreach token [getTokens $file 1 0 -1 -1 {ccomment cppcomment stringlit}] {
+        set tokenValue [lindex $token 0]
+        if {[regexp -nocase $urlRe $tokenValue dummy link] == 1} {
+
+            if {[string index $link 0] == "\#" ||
+                [string first "mailto:" $link] == 0 ||
+                [string first "http:" $link] == 0 ||
+                [string first "https:" $link] == 0 ||
+                [string first "ftp:" $link] == 0 ||
+                [string first "news:" $link] == 0 ||
+                [string first "javascript:" $link] == 0} {
+                continue
+            }
+
+            set lineNumber [lindex $token 1]
+
+            if {[string first "file:" $link] == 0} {
+                report $file $lineNumber "URL links to files are not allowed"
+                continue
+            }
+
+            if {[regexp {[ \<\>\'\{\}\|\\\^\[\]]} $link] == 1} {
+                report $file $lineNumber "URL link contains illegal character(s)"
+                continue
+            }
+
+            set plainLink $link
+            set pos [string first "\#" $link]
+            if {$pos != -1} {
+                set plainLink [string range $link 0 [expr $pos - 1]]
+            }
+
+            if {[string first "\#" $link [expr $pos + 1]] != -1} {
+                report $file $lineNumber "URL link contains invalid bookmark"
+            }
+
+            set completeLink [file join [file dirname $file] $plainLink]
+            if {[file isfile $completeLink] == 0} {
+                report $file $lineNumber "URL points to non-existing file"
+            }
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T016.tcl
+++ b/etc/vera++/scripts/rules/T016.tcl
@@ -1,0 +1,19 @@
+#!/usr/bin/tclsh
+# Calls to min/max should be protected against accidental macro substitution
+
+foreach file [getSourceFileNames] {
+    set prev "none"
+    foreach identifier [getTokens $file 1 0 -1 -1 {}] {
+        set value [lindex $identifier 0]
+        if {($value == "min" || $value == "max") && $prev != "::"} {
+            set lineNumber [lindex $identifier 1]
+            set columnNumber [expr [lindex $identifier 2] + [string length $value]]
+            set restOfLine [string range [getLine $file $lineNumber] $columnNumber end]
+
+            if {[regexp {^[[:space:]]*\(} $restOfLine] == 1} {
+                report $file $lineNumber "min/max potential macro substitution problem"
+            }
+        }
+        set prev $value
+    }
+}

--- a/etc/vera++/scripts/rules/T017.tcl
+++ b/etc/vera++/scripts/rules/T017.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# Unnamed namespaces are not allowed in header files
+
+foreach fileName [getSourceFileNames] {
+    set extension [file extension $fileName]
+    if {[lsearch {.h .hh .hpp .hxx .ipp} $extension] != -1} {
+
+        set state "start"
+        foreach token [getTokens $fileName 1 0 -1 -1 {namespace identifier leftbrace}] {
+            set type [lindex $token 3]
+
+            if {$state == "namespace" && $type == "leftbrace"} {
+                report $fileName $namespaceLine "unnamed namespace not allowed in header file"
+            }
+
+            if {$type == "namespace"} {
+                set namespaceLine [lindex $token 1]
+            }
+
+            set state $type
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T018.tcl
+++ b/etc/vera++/scripts/rules/T018.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# using namespace are not allowed in header files
+
+foreach fileName [getSourceFileNames] {
+    set extension [file extension $fileName]
+    if {[lsearch {.h .hh .hpp .hxx .ipp} $extension] != -1} {
+
+        set state "start"
+        foreach token [getTokens $fileName 1 0 -1 -1 {using namespace identifier}] {
+            set type [lindex $token 3]
+
+            if {$state == "using" && $type == "namespace"} {
+                report $fileName $usingLine "using namespace not allowed in header file"
+            }
+
+            if {$type == "using"} {
+                set usingLine [lindex $token 1]
+            }
+
+            set state $type
+        }
+    }
+}

--- a/etc/vera++/scripts/rules/T019.tcl
+++ b/etc/vera++/scripts/rules/T019.tcl
@@ -1,0 +1,48 @@
+#!/usr/bin/tclsh
+# control structures should have complete curly-braced block of code
+
+foreach fileName [getSourceFileNames] {
+
+    set state "start"
+    set prev ""
+    set pp_pragma_line -1
+    foreach token [getTokens $fileName 1 0 -1 -1 {for if while do else leftparen rightparen leftbrace rightbrace semicolon pp_pragma}] {
+        set type [lindex $token 3]
+        set line [lindex $token 1]
+
+        if {$state == "control"} {
+            if {$type == "leftparen"} {
+                incr parenCount				
+            } elseif {$type == "rightparen"} {
+                incr parenCount -1
+                if {$parenCount == 0} {
+                    set state "expectedblock"
+                }
+            }
+
+        } elseif {$state == "expectedblock"} {
+            if {$prev == "else" && $type == "if" } {
+              # skip
+            } elseif {$type != "leftbrace"} {
+                set line [lindex $token 1]
+                report $fileName $line "full block {} expected in the control structure"
+            }
+            set state "block"
+        }
+
+        if {$type == "pp_pragma"} {
+          set pp_pragma_line $line
+        } elseif {$pp_pragma_line != $line} {
+            if {$type == "for" || $type == "if"} {
+                set parenCount 0
+                set state "control"
+            } elseif {$type == "do" || $type == "else"} {
+                set state "expectedblock"
+            } elseif {$type == "while" && $prev != "rightbrace"} {
+                set parenCount 0
+                set state "control"
+            }
+        }
+        set prev $type
+    }
+}


### PR DESCRIPTION
This PR sets up automatic code style checking with vera++, which is run on Travis CI for each pull request and push, so code submissions don't need to be checked manually. Developers can check style locally by running `./bin/checkStyle`. 

Right now there are ~2500 issues (see https://travis-ci.org/petebachant/OpenFOAM-dev/builds/152833536), which may indicate the rules are too strict, but these can be adjusted by tweaking or removing rules from `etc/vera++`. Some legitimate issues are being caught however:

```
./src/triSurface/triSurface/surfacePatch/surfacePatch.C:49: error L005: too many consecutive empty lines
```