### PR TITLE
swap the names between the macro BINARY_TYPE_FUNCTION_SF and the macro BINARY_TYPE_FUNCTION_FS

### DIFF
--- a/src/OpenFOAM/fields/FieldFields/FieldField/FieldFieldFunctionsM.C
+++ b/src/OpenFOAM/fields/FieldFields/FieldField/FieldFieldFunctionsM.C
@@ -200,7 +200,7 @@ tmp<FieldField<Field, ReturnType>> Func                                        \
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#define BINARY_TYPE_FUNCTION_SF(ReturnType, Type1, Type2, Func)                \
+#define BINARY_TYPE_FUNCTION_FS(ReturnType, Type1, Type2, Func)                \
                                                                                \
 TEMPLATE                                                                       \
 void Func                                                                      \
@@ -248,7 +248,7 @@ tmp<FieldField<Field, ReturnType>> Func                                        \
 }
 
 
-#define BINARY_TYPE_FUNCTION_FS(ReturnType, Type1, Type2, Func)                \
+#define BINARY_TYPE_FUNCTION_SF(ReturnType, Type1, Type2, Func)                \
                                                                                \
 TEMPLATE                                                                       \
 void Func                                                                      \


### PR DESCRIPTION
Hi, I think the two macros: BINARY_TYPE_FUNCTION_SF and BINARY_TYPE_FUNCTION_FS in the file  src/OpenFOAM/fields/FieldFields/FieldField/FieldFieldFunctionsM.C  define a series of functions which act on two input data, one is a pile of objects and the other is a single object. And then they generate an output data which is also a pile of objects. Here I guess the postfix "SF" indicates that the 1st input data is a single object and the 2nd input data is a pile of objects which is a FieldField type here (It contains a heap array with pointers as the elements, and each pointer points to a new heap array which holds the data). Whereas the postfix "FS" indicates that the two input data are in the reverse order. To be consistent with all the other corresponding macros, I think the two macro names should be swapped for a better code reading, although it does not influence the binary execution file at all. I haven't yet found more explanation about those macros, What do ‘F' and 'S' mean? Is my guess right?