### PR TITLE
RunTime Selection for multi-argument templates

### DIFF
--- a/src/OpenFOAM/db/runTimeSelection/construction/TemplatedRunTimeSelection.H
+++ b/src/OpenFOAM/db/runTimeSelection/construction/TemplatedRunTimeSelection.H
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Description
+    RunTime selection for templated class with multiple template args.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef TemplatedRunTimeSelection_H
+#define TemplatedRunTimeSelection_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define defineVariadicTemplatedRunTimeSelectionTablePtr\
+(baseType,argNames,Targs...)                                                   \
+    \
+    /* Initialize constructorsTable pointer */                                 \
+    template<>                                                                 \
+    baseType<Targs >::argNames##ConstructorTable*                              \
+        baseType<Targs >::argNames##ConstructorTablePtr_ = nullptr;            \
+                                                                               \
+    /* Specialize Construction method for the RunTime Table */                 \
+    template<>                                                                 \
+    void baseType<Targs >::construct##argNames##ConstructorTables()            \
+    {                                                                          \
+        static bool constructed = false;                                       \
+        if (!constructed)                                                      \
+        {                                                                      \
+            constructed = true;                                                \
+            baseType<Targs >::argNames##ConstructorTablePtr_                   \
+                = new baseType<Targs >::argNames##ConstructorTable;            \
+        }                                                                      \
+    }                                                                          \
+    /* Specialize Deconstruction method for the RunTime Table */               \
+    template<>                                                                 \
+    void baseType<Targs >::destroy##argNames##ConstructorTables()              \
+    {                                                                          \
+        if (baseType<Targs >::argNames##ConstructorTablePtr_)                  \
+        {                                                                      \
+            delete baseType<Targs >::argNames##ConstructorTablePtr_;           \
+            baseType<Targs >::argNames##ConstructorTablePtr_ = nullptr;        \
+        }                                                                      \
+    }
+
+
+#define defineVariadicTemplatedRunTimeSelectionTable(baseType,Targs...)        \
+    template<>                                                                 \
+    const ::Foam::word baseType<Targs >::typeName                              \
+        (baseType<Targs >::typeName_());                                       \
+                                                                               \
+    template<>                                                                 \
+    int baseType<Targs >::debug                                                \
+    (                                                                          \
+        ::Foam::debug::debugSwitch(baseType<Targs >::typeName_(), 0)           \
+    );                                                                         \
+    template<>                                                                 \
+    const Foam::RegisterDebugSwitch<baseType<Targs >>                          \
+    Foam::RegisterDebugSwitch<baseType<Targs >>                                \
+        ::registerDebugSwitch(baseType<Targs >::typeName_());                  \
+    defineVariadicTemplatedRunTimeSelectionTablePtr(baseType,dictionary,Targs);
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/OpenFOAM/db/runTimeSelection/construction/addToTemplatedRunTimeSelection.H
+++ b/src/OpenFOAM/db/runTimeSelection/construction/addToTemplatedRunTimeSelection.H
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Description
+    Macros to add child classes to the parent's RunTime selection table.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef addToTemplatedRunTimeSelection_H
+#define addToTemplatedRunTimeSelection_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#define makeTemplatedModel(baseType,childType,TargName,ns,Targs...)            \
+                                                                               \
+    /* Define child type name */                                               \
+    template<>                                                                 \
+    const ::Foam::word ns::childType<Targs >::                                 \
+        typeName(ns::childType<Targs >::typeName_());                          \
+                                                                               \
+    /* Define child debug switch */                                            \
+    template<>                                                                 \
+    int ns::childType<Targs >::debug                                           \
+    (                                                                          \
+        ::Foam::debug::debugSwitch(ns::childType<Targs >::typeName_(), 0)      \
+    );                                                                         \
+    /* Register the debug switch */                                            \
+    template<>                                                                 \
+    const Foam::RegisterDebugSwitch<ns::childType<Targs >>                     \
+    Foam::RegisterDebugSwitch<ns::childType<Targs >>                           \
+        ::registerDebugSwitch(ns::childType<Targs >::typeName_());             \
+                                                                               \
+    /* Add child to the base's run-time selection tabe */                      \
+    namespace ns {                                                             \
+    baseType<Targs >::adddictionaryConstructorToTable<childType<Targs >>       \
+    add##phaseType##TargName##argNames##ConstructorTo##baseType##Targ##Table_; \
+    }
+    
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/Make/files
+++ b/test/TemplatedRunTimeSelection/Make/files
@@ -1,0 +1,6 @@
+baseClass/baseClasses.C
+childClass/childClasses.C
+
+test.C
+
+EXE = test

--- a/test/TemplatedRunTimeSelection/Make/options
+++ b/test/TemplatedRunTimeSelection/Make/options
@@ -1,0 +1,10 @@
+EXE_INC = \
+    -I$(LIB_SRC)/OpenFOAM/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I./lnInclude
+    
+EXE_LIBS = \
+    -lOpenFOAM \
+    -lfiniteVolume \
+    -lmeshTools

--- a/test/TemplatedRunTimeSelection/baseClass/baseClass.C
+++ b/test/TemplatedRunTimeSelection/baseClass/baseClass.C
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "baseClass.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+template<class T1, class T2>
+Foam::autoPtr<Foam::baseClass<T1, T2>>
+Foam::baseClass<T1, T2>::New
+(
+    word i, float f
+)
+{
+    const word type = i;
+                                                                                
+    Info<< "Selecting type " << type << endl;   
+    
+    typename dictionaryConstructorTable::iterator cstrIter =                    
+        dictionaryConstructorTablePtr_->find(type);                        
+                                                                                
+    if (cstrIter == dictionaryConstructorTablePtr_->end())                      
+    {                                                                           
+        FatalErrorInFunction                                                    
+            << "Unknown type "                                  
+            << type << nl << nl                                            
+            << "Valid types:" << endl                           
+            << dictionaryConstructorTablePtr_->sortedToc()                      
+            << exit(FatalError);                                                
+    }                                                                           
+                                                                                
+    return autoPtr<baseClass> ( cstrIter()(i, f) );          
+}
+
+
+template<class T1, class T2>
+Foam::baseClass<T1, T2>::~baseClass()
+{}
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/baseClass/baseClass.H
+++ b/test/TemplatedRunTimeSelection/baseClass/baseClass.H
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef baseClass_H
+#define baseClass_H
+
+#include "autoPtr.H"
+#include "runTimeSelectionTables.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                          Class baseClass Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class T1, class T2>
+class baseClass
+{
+public:
+    
+    //- Runtime type information
+    TypeName("baseClass");
+
+    // Declare run-time constructor selection table
+    declareRunTimeSelectionTable
+    (
+        autoPtr,
+        baseClass,
+        dictionary,
+        (
+            word i, float f
+        ),
+        (i, f)
+    );
+
+    // Constructors
+
+        // Construct from components
+        baseClass (word i, float f) {};
+
+        // Construct from copy
+        baseClass (const baseClass&) = delete;
+
+    // Selectors
+
+        //- Return a reference to the selected baseClass
+        static autoPtr<baseClass> New
+        (
+            word i, float f
+        );
+
+
+    //- Destructor
+    virtual ~baseClass();
+
+    // Member Functions
+
+        //- Corrector
+        virtual void correct() = 0;
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        baseClass& operator=(const baseClass&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "baseClass.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/baseClass/baseClasses.C
+++ b/test/TemplatedRunTimeSelection/baseClass/baseClasses.C
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "baseClass.H"
+#include "TemplatedRunTimeSelection.H"
+
+namespace Foam {
+
+// Define Types
+defineVariadicTemplatedRunTimeSelectionTable(baseClass, int, float);
+defineVariadicTemplatedRunTimeSelectionTable(baseClass, float, double);
+
+}
+
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/childClass/childClass.C
+++ b/test/TemplatedRunTimeSelection/childClass/childClass.C
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "childClass.H"
+
+namespace Foam 
+{
+namespace models 
+{
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class T1, class T2>
+childClass<T1, T2>::childClass
+(
+    word i, float f
+)
+:
+    baseClass<T1, T2>(i, f)
+{
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class T1, class T2>
+childClass<T1, T2>::~childClass() {}
+
+template<class T1, class T2>
+void childClass<T1, T2>::spec()
+{
+    Info << "From generic template" << endl;
+}
+
+}
+}
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/childClass/childClass.H
+++ b/test/TemplatedRunTimeSelection/childClass/childClass.H
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+SourceFiles
+    childClass.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef childClass_H
+#define childClass_H
+
+#include "baseClass.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace models
+{
+
+/*---------------------------------------------------------------------------*\
+                   Class childClass Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class T1, class T2>
+class childClass
+:
+    public baseClass<T1, T2>
+{
+public:
+
+    //- Runtime type information
+    ClassName("childClass");
+
+    inline void spec();
+
+    // Constructors
+
+        // Construct from components
+        childClass
+        (
+            word i,
+            float f
+        );
+
+        // Construct from copy
+        childClass (const childClass&) = delete;
+
+	// Destructor
+	virtual ~childClass();
+
+    // Member Functions
+
+		//- Phase fields update
+		virtual void correct() override { spec(); }
+
+    // Member operators
+
+        //- Disallow default bitwise assignment
+        childClass& operator=(const childClass&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace phases
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+    #include "childClass.C"
+    #include "childClassImpl.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/childClass/childClassImpl.C
+++ b/test/TemplatedRunTimeSelection/childClass/childClassImpl.C
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef childClass_ImpH
+#define childClass_ImpH
+
+#include "childClass.H"
+
+namespace Foam 
+{
+
+namespace models
+{
+
+
+// Member function specialization for <float, double>
+template<>
+void childClass<float, double>::spec()
+{
+    Info << "Run from specialized <float, double>" << endl;
+}
+
+}
+
+}
+
+#endif

--- a/test/TemplatedRunTimeSelection/childClass/childClasses.C
+++ b/test/TemplatedRunTimeSelection/childClass/childClasses.C
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "childClass.H"
+#include "addToTemplatedRunTimeSelection.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+makeTemplatedModel(baseClass,childClass,IntFloat,models,int, float);
+makeTemplatedModel(baseClass,childClass,FloatDouble,models,float, double);
+
+}
+
+// ************************************************************************* //

--- a/test/TemplatedRunTimeSelection/test.C
+++ b/test/TemplatedRunTimeSelection/test.C
@@ -1,0 +1,12 @@
+#include "baseClass.H"
+
+using namespace Foam;
+
+int main(int argc, char* argv[]) {
+
+    auto ptr = Foam::baseClass<int, float>::New("childClass", 5.0);
+    ptr->correct();
+    auto ptr2 = Foam::baseClass<float, double>::New("childClass", 8.0);
+    ptr2->correct();
+    return 0;
+}


### PR DESCRIPTION
**I opened this draft PR for discussion purposes only. The code is far from being ready to actually get merged!**

## Why open this PR

As far as I know, standard RunTime Selection Construction macros allow only for single-argument templates to be involved
with RunTime selection.
I want to know if this is a **design choice** or if I can safely improve on the current situation by employing variadic macros to support multi-arguments template classes.

## What this PR does

I added two macro definitions `defineVariadicTemplatedRunTimeSelectionTable` and `makeTemplatedModel` which do what the standard ones do. The only difference is that you can list any number of template arguments at the end.

## Was the added code tested?

Yes, minimally and with make-believe base and child template classes. The tests were added to the `/test` directory.

## Code Limitations
- Not so optimal macro names, I know.
- For faster and cleaner development, I skipped replicating the default macros one by one but instead put everything into a single macro which resulted in forced `debugSwitch` definition but that's easy to fix.
- I assume child classes will always belong to a sub-namespace. Also easy to change.

## What to discuss?

If any of you got some time to spare, could you please clarify if you think I'm missing out on anything while designing things this way?

I asked the same question on [cfd-online](https://www.cfd-online.com/Forums/openfoam-programming-development/230031-runtime-selection-templates-mess.html) but it received no responses.