### PR TITLE
Corrected authorship designation for 2008-2011 user contribution

### DIFF
--- a/applications/test/DLList/Test-DLList.C
+++ b/applications/test/DLList/Test-DLList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/Dictionary/Test-Dictionary.C
+++ b/applications/test/Dictionary/Test-Dictionary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/DynamicList/Test-DynamicList.C
+++ b/applications/test/DynamicList/Test-DynamicList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/FixedList/Test-FixedList.C
+++ b/applications/test/FixedList/Test-FixedList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/HashSet/Test-hashSet.C
+++ b/applications/test/HashSet/Test-hashSet.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/HashTable/Test-hashTable.C
+++ b/applications/test/HashTable/Test-hashTable.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/HashTable3/Test-HashTable3.C
+++ b/applications/test/HashTable3/Test-HashTable3.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/Hashing/Test-Hashing.C
+++ b/applications/test/Hashing/Test-Hashing.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/ISLList/Test-ISLList.C
+++ b/applications/test/ISLList/Test-ISLList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/IndirectList/Test-IndirectList.C
+++ b/applications/test/IndirectList/Test-IndirectList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/List/Test-List.C
+++ b/applications/test/List/Test-List.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/PackedList/Test-PackedList.C
+++ b/applications/test/PackedList/Test-PackedList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/PackedList1/Test-PackedList1.C
+++ b/applications/test/PackedList1/Test-PackedList1.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/PackedList3/Test-PackedList3.C
+++ b/applications/test/PackedList3/Test-PackedList3.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/PackedList4/Test-PackedList4.C
+++ b/applications/test/PackedList4/Test-PackedList4.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/Polynomial/Test-Polynomial.C
+++ b/applications/test/Polynomial/Test-Polynomial.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/PtrList/Test-PtrList.C
+++ b/applications/test/PtrList/Test-PtrList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/SLList/Test-SLList.C
+++ b/applications/test/SLList/Test-SLList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/UDictionary/Test-UDictionary.C
+++ b/applications/test/UDictionary/Test-UDictionary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/UIndirectList/Test-UIndirectList.C
+++ b/applications/test/UIndirectList/Test-UIndirectList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/codeStream/Test-codeStream.C
+++ b/applications/test/codeStream/Test-codeStream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/dictionary/Test-dictionary.C
+++ b/applications/test/dictionary/Test-dictionary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/fileName/Test-fileName.C
+++ b/applications/test/fileName/Test-fileName.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/fileNameClean/Test-fileNameClean.C
+++ b/applications/test/fileNameClean/Test-fileNameClean.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/findTimes/Test-findTimes.C
+++ b/applications/test/findTimes/Test-findTimes.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/foamVersion/Test-foamVersionString.C
+++ b/applications/test/foamVersion/Test-foamVersionString.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/labelRanges/Test-labelRanges.C
+++ b/applications/test/labelRanges/Test-labelRanges.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/memInfo/Test-memInfo.C
+++ b/applications/test/memInfo/Test-memInfo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/mvBak/Test-mvBak.C
+++ b/applications/test/mvBak/Test-mvBak.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/regex/Test-regex.C
+++ b/applications/test/regex/Test-regex.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/sha1/Test-SHA1.C
+++ b/applications/test/sha1/Test-SHA1.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/sizeof/Test-sizeof.C
+++ b/applications/test/sizeof/Test-sizeof.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/sort/Test-sortList.C
+++ b/applications/test/sort/Test-sortList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/spline/Test-spline.C
+++ b/applications/test/spline/Test-spline.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/string/Test-string.C
+++ b/applications/test/string/Test-string.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/stringList/Test-stringList.C
+++ b/applications/test/stringList/Test-stringList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/tokenize/Test-tokenize.C
+++ b/applications/test/tokenize/Test-tokenize.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/test/wordRe/Test-wordRe.C
+++ b/applications/test/wordRe/Test-wordRe.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/mesh/conversion/foamToStarMesh/foamToStarMesh.C
+++ b/applications/utilities/mesh/conversion/foamToStarMesh/foamToStarMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/mesh/conversion/foamToSurface/foamToSurface.C
+++ b/applications/utilities/mesh/conversion/foamToSurface/foamToSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/mesh/conversion/ideasUnvToFoam/ideasUnvToFoam.C
+++ b/applications/utilities/mesh/conversion/ideasUnvToFoam/ideasUnvToFoam.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/mesh/conversion/star4ToFoam/star4ToFoam.C
+++ b/applications/utilities/mesh/conversion/star4ToFoam/star4ToFoam.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/mesh/generation/blockMesh/blockMesh.C
+++ b/applications/utilities/mesh/generation/blockMesh/blockMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/miscellaneous/foamDictionary/foamDictionary.C
+++ b/applications/utilities/miscellaneous/foamDictionary/foamDictionary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2016-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/miscellaneous/foamListTimes/foamListTimes.C
+++ b/applications/utilities/miscellaneous/foamListTimes/foamListTimes.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/parallelProcessing/decomposePar/decomposePar.C
+++ b/applications/utilities/parallelProcessing/decomposePar/decomposePar.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightField.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightField.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightMesh.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightMesh.H
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsight/ensightMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsight/foamToEnsight.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsight/foamToEnsight.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/ensightOutputFunctions.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/ensightOutputFunctions.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/ensightOutputFunctions.H
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/ensightOutputFunctions.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/foamToEnsightParts.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToEnsightParts/foamToEnsightParts.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/patchWriter.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/patchWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/vtkTopo.C
+++ b/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/vtkTopo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/vtkTopo.H
+++ b/applications/utilities/postProcessing/dataConversion/foamToVTK/foamToVTK/vtkTopo.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/PVFoamReader/vtk/vtkPVFoamReader.cxx
+++ b/applications/utilities/postProcessing/graphics/PVReaders/PVFoamReader/vtk/vtkPVFoamReader.cxx
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/PVFoamReader/vtk/vtkPVFoamReader.h
+++ b/applications/utilities/postProcessing/graphics/PVReaders/PVFoamReader/vtk/vtkPVFoamReader.h
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/PVblockMeshReader/vtk/vtkPVblockMeshReader.cxx
+++ b/applications/utilities/postProcessing/graphics/PVReaders/PVblockMeshReader/vtk/vtkPVblockMeshReader.cxx
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/PVblockMeshReader/vtk/vtkPVblockMeshReader.h
+++ b/applications/utilities/postProcessing/graphics/PVReaders/PVblockMeshReader/vtk/vtkPVblockMeshReader.h
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkOpenFOAMPoints.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkOpenFOAMPoints.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkOpenFOAMTupleRemap.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkOpenFOAMTupleRemap.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoam.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoam.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoam.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoam.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamAddToSelection.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamAddToSelection.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamFields.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamFields.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamLagrangianFields.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamLagrangianFields.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMesh.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshLagrangian.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshLagrangian.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshSet.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshSet.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshVolume.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshVolume.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshZone.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamMeshZone.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamPatchField.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamPatchField.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamPointFields.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamPointFields.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamSurfaceField.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamSurfaceField.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamTemplates.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamUpdateInfo.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamUpdateInfo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamUtils.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamUtils.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamVolFields.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVFoam/vtkPVFoamVolFields.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkOpenFOAMPoints.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkOpenFOAMPoints.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMesh.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMesh.H
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMeshConvert.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMeshConvert.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMeshUtils.C
+++ b/applications/utilities/postProcessing/graphics/PVReaders/vtkPVblockMesh/vtkPVblockMeshUtils.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceConvert/surfaceConvert.C
+++ b/applications/utilities/surface/surfaceConvert/surfaceConvert.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceFeatureConvert/surfaceFeatureConvert.C
+++ b/applications/utilities/surface/surfaceFeatureConvert/surfaceFeatureConvert.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceMeshConvert/surfaceMeshConvert.C
+++ b/applications/utilities/surface/surfaceMeshConvert/surfaceMeshConvert.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceMeshConvertTesting/surfaceMeshConvertTesting.C
+++ b/applications/utilities/surface/surfaceMeshConvertTesting/surfaceMeshConvertTesting.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceMeshExport/surfaceMeshExport.C
+++ b/applications/utilities/surface/surfaceMeshExport/surfaceMeshExport.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceMeshImport/surfaceMeshImport.C
+++ b/applications/utilities/surface/surfaceMeshImport/surfaceMeshImport.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/applications/utilities/surface/surfaceMeshInfo/surfaceMeshInfo.C
+++ b/applications/utilities/surface/surfaceMeshInfo/surfaceMeshInfo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/bin/foamCleanPath
+++ b/bin/foamCleanPath
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamCleanPolyMesh
+++ b/bin/foamCleanPolyMesh
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2010 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamCleanTutorials
+++ b/bin/foamCleanTutorials
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamEtcFile
+++ b/bin/foamEtcFile
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2009-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamExec
+++ b/bin/foamExec
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamJob
+++ b/bin/foamJob
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamLog
+++ b/bin/foamLog
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2009-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/foamNew
+++ b/bin/foamNew
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2010 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/paraFoam
+++ b/bin/paraFoam
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/tools/CleanFunctions
+++ b/bin/tools/CleanFunctions
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/tools/RunFunctions
+++ b/bin/tools/RunFunctions
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/bin/tools/foamConfigurePaths
+++ b/bin/tools/foamConfigurePaths
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/aliases
+++ b/etc/config.csh/aliases
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/example/compiler
+++ b/etc/config.csh/example/compiler
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/example/openmpi
+++ b/etc/config.csh/example/openmpi
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/example/paraview
+++ b/etc/config.csh/example/paraview
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/example/prefs.csh
+++ b/etc/config.csh/example/prefs.csh
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/paraview
+++ b/etc/config.csh/paraview
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/settings
+++ b/etc/config.csh/settings
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.csh/unset
+++ b/etc/config.csh/unset
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/aliases
+++ b/etc/config.sh/aliases
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/example/compiler
+++ b/etc/config.sh/example/compiler
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/example/openmpi
+++ b/etc/config.sh/example/openmpi
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/example/paraview
+++ b/etc/config.sh/example/paraview
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/example/prefs.sh
+++ b/etc/config.sh/example/prefs.sh
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/paraview
+++ b/etc/config.sh/paraview
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/scotch
+++ b/etc/config.sh/scotch
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2010-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/settings
+++ b/etc/config.sh/settings
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/config.sh/unset
+++ b/etc/config.sh/unset
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/etc/cshrc
+++ b/etc/cshrc
@@ -5,6 +5,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/src/OSspecific/POSIX/POSIX.C
+++ b/src/OSspecific/POSIX/POSIX.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/fileMonitor.C
+++ b/src/OSspecific/POSIX/fileMonitor.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/fileMonitor.H
+++ b/src/OSspecific/POSIX/fileMonitor.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/memInfo/memInfo.C
+++ b/src/OSspecific/POSIX/memInfo/memInfo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/memInfo/memInfo.H
+++ b/src/OSspecific/POSIX/memInfo/memInfo.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/regExp.C
+++ b/src/OSspecific/POSIX/regExp.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OSspecific/POSIX/regExp.H
+++ b/src/OSspecific/POSIX/regExp.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashSet/HashSet.C
+++ b/src/OpenFOAM/containers/HashTables/HashSet/HashSet.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashSet/HashSet.H
+++ b/src/OpenFOAM/containers/HashTables/HashSet/HashSet.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashTable/HashTable.C
+++ b/src/OpenFOAM/containers/HashTables/HashTable/HashTable.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashTable/HashTable.H
+++ b/src/OpenFOAM/containers/HashTables/HashTable/HashTable.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashTable/HashTableCore.C
+++ b/src/OpenFOAM/containers/HashTables/HashTable/HashTableCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashTable/HashTableI.H
+++ b/src/OpenFOAM/containers/HashTables/HashTable/HashTableI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/HashTable/HashTableIO.C
+++ b/src/OpenFOAM/containers/HashTables/HashTable/HashTableIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/HashTables/Map/Map.H
+++ b/src/OpenFOAM/containers/HashTables/Map/Map.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Identifiers/Keyed/Keyed.H
+++ b/src/OpenFOAM/containers/Identifiers/Keyed/Keyed.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Identifiers/Keyed/KeyedI.H
+++ b/src/OpenFOAM/containers/Identifiers/Keyed/KeyedI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/CompactListList/CompactListList.C
+++ b/src/OpenFOAM/containers/Lists/CompactListList/CompactListList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/CompactListList/CompactListList.H
+++ b/src/OpenFOAM/containers/Lists/CompactListList/CompactListList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/CompactListList/CompactListListI.H
+++ b/src/OpenFOAM/containers/Lists/CompactListList/CompactListListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/DynamicList/DynamicList.C
+++ b/src/OpenFOAM/containers/Lists/DynamicList/DynamicList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/DynamicList/DynamicList.H
+++ b/src/OpenFOAM/containers/Lists/DynamicList/DynamicList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/DynamicList/DynamicListI.H
+++ b/src/OpenFOAM/containers/Lists/DynamicList/DynamicListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/FixedList/FixedList.C
+++ b/src/OpenFOAM/containers/Lists/FixedList/FixedList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/FixedList/FixedList.H
+++ b/src/OpenFOAM/containers/Lists/FixedList/FixedList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/FixedList/FixedListI.H
+++ b/src/OpenFOAM/containers/Lists/FixedList/FixedListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/FixedList/FixedListIO.C
+++ b/src/OpenFOAM/containers/Lists/FixedList/FixedListIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/IndirectList/IndirectList.H
+++ b/src/OpenFOAM/containers/Lists/IndirectList/IndirectList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/IndirectList/IndirectListI.H
+++ b/src/OpenFOAM/containers/Lists/IndirectList/IndirectListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/List/List.C
+++ b/src/OpenFOAM/containers/Lists/List/List.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/List/List.H
+++ b/src/OpenFOAM/containers/Lists/List/List.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/List/ListI.H
+++ b/src/OpenFOAM/containers/Lists/List/ListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/List/ListIO.C
+++ b/src/OpenFOAM/containers/Lists/List/ListIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/ListOps/ListOps.C
+++ b/src/OpenFOAM/containers/Lists/ListOps/ListOps.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/ListOps/ListOps.H
+++ b/src/OpenFOAM/containers/Lists/ListOps/ListOps.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/ListOps/ListOpsTemplates.C
+++ b/src/OpenFOAM/containers/Lists/ListOps/ListOpsTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedBoolList.C
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedBoolList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedBoolList.H
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedBoolList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedBoolListI.H
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedBoolListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedList.C
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedList.H
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedListCore.C
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedListCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PackedList/PackedListI.H
+++ b/src/OpenFOAM/containers/Lists/PackedList/PackedListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PtrList/PtrList.C
+++ b/src/OpenFOAM/containers/Lists/PtrList/PtrList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PtrList/PtrList.H
+++ b/src/OpenFOAM/containers/Lists/PtrList/PtrList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/PtrList/PtrListI.H
+++ b/src/OpenFOAM/containers/Lists/PtrList/PtrListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/SortableList/SortableList.C
+++ b/src/OpenFOAM/containers/Lists/SortableList/SortableList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/SortableList/SortableList.H
+++ b/src/OpenFOAM/containers/Lists/SortableList/SortableList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/SubList/SubList.H
+++ b/src/OpenFOAM/containers/Lists/SubList/SubList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/SubList/SubListI.H
+++ b/src/OpenFOAM/containers/Lists/SubList/SubListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectList.H
+++ b/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectListI.H
+++ b/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectListIO.C
+++ b/src/OpenFOAM/containers/Lists/UIndirectList/UIndirectListIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UList/UList.C
+++ b/src/OpenFOAM/containers/Lists/UList/UList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UList/UList.H
+++ b/src/OpenFOAM/containers/Lists/UList/UList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UList/UListI.H
+++ b/src/OpenFOAM/containers/Lists/UList/UListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UList/UListIO.C
+++ b/src/OpenFOAM/containers/Lists/UList/UListIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UPtrList/UPtrList.C
+++ b/src/OpenFOAM/containers/Lists/UPtrList/UPtrList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UPtrList/UPtrList.H
+++ b/src/OpenFOAM/containers/Lists/UPtrList/UPtrList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/Lists/UPtrList/UPtrListI.H
+++ b/src/OpenFOAM/containers/Lists/UPtrList/UPtrListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/NamedEnum/NamedEnum.C
+++ b/src/OpenFOAM/containers/NamedEnum/NamedEnum.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/containers/NamedEnum/NamedEnum.H
+++ b/src/OpenFOAM/containers/NamedEnum/NamedEnum.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobject/IOobject.C
+++ b/src/OpenFOAM/db/IOobject/IOobject.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobject/IOobject.H
+++ b/src/OpenFOAM/db/IOobject/IOobject.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobject/IOobjectI.H
+++ b/src/OpenFOAM/db/IOobject/IOobjectI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobject/IOobjectWriteHeader.C
+++ b/src/OpenFOAM/db/IOobject/IOobjectWriteHeader.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobjectList/IOobjectList.C
+++ b/src/OpenFOAM/db/IOobjectList/IOobjectList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOobjectList/IOobjectList.H
+++ b/src/OpenFOAM/db/IOobjectList/IOobjectList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Fstreams/IFstream.C
+++ b/src/OpenFOAM/db/IOstreams/Fstreams/IFstream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Fstreams/IFstream.H
+++ b/src/OpenFOAM/db/IOstreams/Fstreams/IFstream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Fstreams/OFstream.C
+++ b/src/OpenFOAM/db/IOstreams/Fstreams/OFstream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Fstreams/OFstream.H
+++ b/src/OpenFOAM/db/IOstreams/Fstreams/OFstream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/IOstreams/Istream.C
+++ b/src/OpenFOAM/db/IOstreams/IOstreams/Istream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/IOstreams/Istream.H
+++ b/src/OpenFOAM/db/IOstreams/IOstreams/Istream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/IOstreams/Ostream.C
+++ b/src/OpenFOAM/db/IOstreams/IOstreams/Ostream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Sstreams/ISstream.C
+++ b/src/OpenFOAM/db/IOstreams/Sstreams/ISstream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Sstreams/ISstream.H
+++ b/src/OpenFOAM/db/IOstreams/Sstreams/ISstream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Sstreams/OSstream.H
+++ b/src/OpenFOAM/db/IOstreams/Sstreams/OSstream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/StringStreams/IStringStream.H
+++ b/src/OpenFOAM/db/IOstreams/StringStreams/IStringStream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/StringStreams/OStringStream.H
+++ b/src/OpenFOAM/db/IOstreams/StringStreams/OStringStream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/Tstreams/ITstream.H
+++ b/src/OpenFOAM/db/IOstreams/Tstreams/ITstream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
+++ b/src/OpenFOAM/db/IOstreams/hashes/OSHA1stream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/Time/Time.C
+++ b/src/OpenFOAM/db/Time/Time.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/Time/Time.H
+++ b/src/OpenFOAM/db/Time/Time.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/Time/TimeIO.C
+++ b/src/OpenFOAM/db/Time/TimeIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/Time/timeSelector.C
+++ b/src/OpenFOAM/db/Time/timeSelector.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/Time/timeSelector.H
+++ b/src/OpenFOAM/db/Time/timeSelector.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionary.C
+++ b/src/OpenFOAM/db/dictionary/dictionary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionary.H
+++ b/src/OpenFOAM/db/dictionary/dictionary.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionaryEntry/dictionaryEntry.H
+++ b/src/OpenFOAM/db/dictionary/dictionaryEntry/dictionaryEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionaryEntry/dictionaryEntryIO.C
+++ b/src/OpenFOAM/db/dictionary/dictionaryEntry/dictionaryEntryIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionaryIO.C
+++ b/src/OpenFOAM/db/dictionary/dictionaryIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/dictionaryTemplates.C
+++ b/src/OpenFOAM/db/dictionary/dictionaryTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/entry/entryIO.C
+++ b/src/OpenFOAM/db/dictionary/entry/entryIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/codeStream/codeStream.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/codeStream/codeStream.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/codeStream/codeStream.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/codeStream/codeStream.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/functionEntry/functionEntry.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/functionEntry/functionEntry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/functionEntry/functionEntry.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/functionEntry/functionEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/includeEntry/includeEntry.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/includeEntry/includeEntry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/includeEntry/includeEntry.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/includeEntry/includeEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/includeIfPresentEntry/includeIfPresentEntry.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/includeIfPresentEntry/includeIfPresentEntry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/includeIfPresentEntry/includeIfPresentEntry.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/includeIfPresentEntry/includeIfPresentEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/inputModeEntry/inputModeEntry.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/inputModeEntry/inputModeEntry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/inputModeEntry/inputModeEntry.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/inputModeEntry/inputModeEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/removeEntry/removeEntry.C
+++ b/src/OpenFOAM/db/dictionary/functionEntries/removeEntry/removeEntry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/functionEntries/removeEntry/removeEntry.H
+++ b/src/OpenFOAM/db/dictionary/functionEntries/removeEntry/removeEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/keyType/keyType.C
+++ b/src/OpenFOAM/db/dictionary/keyType/keyType.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/keyType/keyType.H
+++ b/src/OpenFOAM/db/dictionary/keyType/keyType.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/keyType/keyTypeI.H
+++ b/src/OpenFOAM/db/dictionary/keyType/keyTypeI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/primitiveEntry/primitiveEntry.H
+++ b/src/OpenFOAM/db/dictionary/primitiveEntry/primitiveEntry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dictionary/primitiveEntry/primitiveEntryIO.C
+++ b/src/OpenFOAM/db/dictionary/primitiveEntry/primitiveEntryIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTable.C
+++ b/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTable.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTable.H
+++ b/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTable.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTableTemplates.C
+++ b/src/OpenFOAM/db/dynamicLibrary/dlLibraryTable/dlLibraryTableTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCode.C
+++ b/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCode.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCode.H
+++ b/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCode.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCodeContext.C
+++ b/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCodeContext.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCodeContext.H
+++ b/src/OpenFOAM/db/dynamicLibrary/dynamicCode/dynamicCodeContext.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/functionObjects/functionObject/functionObject.C
+++ b/src/OpenFOAM/db/functionObjects/functionObject/functionObject.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/functionObjects/functionObject/functionObject.H
+++ b/src/OpenFOAM/db/functionObjects/functionObject/functionObject.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/functionObjects/functionObjectList/functionObjectList.C
+++ b/src/OpenFOAM/db/functionObjects/functionObjectList/functionObjectList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/functionObjects/functionObjectList/functionObjectList.H
+++ b/src/OpenFOAM/db/functionObjects/functionObjectList/functionObjectList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/objectRegistry/objectRegistry.C
+++ b/src/OpenFOAM/db/objectRegistry/objectRegistry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/objectRegistry/objectRegistry.H
+++ b/src/OpenFOAM/db/objectRegistry/objectRegistry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/regIOobject/regIOobject.C
+++ b/src/OpenFOAM/db/regIOobject/regIOobject.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/regIOobject/regIOobject.H
+++ b/src/OpenFOAM/db/regIOobject/regIOobject.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/regIOobject/regIOobjectWrite.C
+++ b/src/OpenFOAM/db/regIOobject/regIOobjectWrite.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/runTimeSelection/construction/addToRunTimeSelectionTable.H
+++ b/src/OpenFOAM/db/runTimeSelection/construction/addToRunTimeSelectionTable.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/runTimeSelection/construction/runTimeSelectionTables.H
+++ b/src/OpenFOAM/db/runTimeSelection/construction/runTimeSelectionTables.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/runTimeSelection/memberFunctions/addToMemberFunctionSelectionTable.H
+++ b/src/OpenFOAM/db/runTimeSelection/memberFunctions/addToMemberFunctionSelectionTable.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/db/runTimeSelection/memberFunctions/memberFunctionSelectionTables.H
+++ b/src/OpenFOAM/db/runTimeSelection/memberFunctions/memberFunctionSelectionTables.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/dimensionedTypes/dimensionedType/dimensionedType.C
+++ b/src/OpenFOAM/dimensionedTypes/dimensionedType/dimensionedType.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/dimensionedTypes/dimensionedType/dimensionedType.H
+++ b/src/OpenFOAM/dimensionedTypes/dimensionedType/dimensionedType.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/fields/Fields/Field/SubField.H
+++ b/src/OpenFOAM/fields/Fields/Field/SubField.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/fields/Fields/Field/SubFieldI.H
+++ b/src/OpenFOAM/fields/Fields/Field/SubFieldI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/argList/argList.C
+++ b/src/OpenFOAM/global/argList/argList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/argList/argList.H
+++ b/src/OpenFOAM/global/argList/argList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/argList/argListI.H
+++ b/src/OpenFOAM/global/argList/argListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/foamVersion.H
+++ b/src/OpenFOAM/global/foamVersion.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/global.Cver
+++ b/src/OpenFOAM/global/global.Cver
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/jobInfo/jobInfo.C
+++ b/src/OpenFOAM/global/jobInfo/jobInfo.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/global/jobInfo/jobInfo.H
+++ b/src/OpenFOAM/global/jobInfo/jobInfo.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/include/OSspecific.H
+++ b/src/OpenFOAM/include/OSspecific.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/memory/autoPtr/autoPtr.H
+++ b/src/OpenFOAM/memory/autoPtr/autoPtr.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/memory/autoPtr/autoPtrI.H
+++ b/src/OpenFOAM/memory/autoPtr/autoPtrI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/memory/tmp/tmp.H
+++ b/src/OpenFOAM/memory/tmp/tmp.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/memory/tmp/tmpI.H
+++ b/src/OpenFOAM/memory/tmp/tmpI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/Identifiers/DynamicID/DynamicID.H
+++ b/src/OpenFOAM/meshes/Identifiers/DynamicID/DynamicID.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/Identifiers/patch/polyPatchID.H
+++ b/src/OpenFOAM/meshes/Identifiers/patch/polyPatchID.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/Identifiers/zones/ZoneIDs.H
+++ b/src/OpenFOAM/meshes/Identifiers/zones/ZoneIDs.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/boundBox/boundBox.C
+++ b/src/OpenFOAM/meshes/boundBox/boundBox.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/boundBox/boundBox.H
+++ b/src/OpenFOAM/meshes/boundBox/boundBox.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/boundBox/boundBoxI.H
+++ b/src/OpenFOAM/meshes/boundBox/boundBoxI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/boundBox/boundBoxTemplates.C
+++ b/src/OpenFOAM/meshes/boundBox/boundBoxTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/edge/edge.H
+++ b/src/OpenFOAM/meshes/meshShapes/edge/edge.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/edge/edgeI.H
+++ b/src/OpenFOAM/meshes/meshShapes/edge/edgeI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/face/face.C
+++ b/src/OpenFOAM/meshes/meshShapes/face/face.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/face/face.H
+++ b/src/OpenFOAM/meshes/meshShapes/face/face.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/face/faceI.H
+++ b/src/OpenFOAM/meshes/meshShapes/face/faceI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/face/faceTemplates.C
+++ b/src/OpenFOAM/meshes/meshShapes/face/faceTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/triFace/triFace.H
+++ b/src/OpenFOAM/meshes/meshShapes/triFace/triFace.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/triFace/triFaceI.H
+++ b/src/OpenFOAM/meshes/meshShapes/triFace/triFaceI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/meshShapes/triFace/triFaceTemplates.C
+++ b/src/OpenFOAM/meshes/meshShapes/triFace/triFaceTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyBoundaryMesh/polyBoundaryMesh.C
+++ b/src/OpenFOAM/meshes/polyMesh/polyBoundaryMesh/polyBoundaryMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyBoundaryMesh/polyBoundaryMesh.H
+++ b/src/OpenFOAM/meshes/polyMesh/polyBoundaryMesh/polyBoundaryMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyMesh.C
+++ b/src/OpenFOAM/meshes/polyMesh/polyMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyMesh.H
+++ b/src/OpenFOAM/meshes/polyMesh/polyMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyMeshFromShapeMesh.C
+++ b/src/OpenFOAM/meshes/polyMesh/polyMeshFromShapeMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/polyMeshInitMesh.C
+++ b/src/OpenFOAM/meshes/polyMesh/polyMeshInitMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/ZoneMesh/ZoneMesh.C
+++ b/src/OpenFOAM/meshes/polyMesh/zones/ZoneMesh/ZoneMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/ZoneMesh/ZoneMesh.H
+++ b/src/OpenFOAM/meshes/polyMesh/zones/ZoneMesh/ZoneMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/cellZone/cellZone.C
+++ b/src/OpenFOAM/meshes/polyMesh/zones/cellZone/cellZone.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/cellZone/cellZone.H
+++ b/src/OpenFOAM/meshes/polyMesh/zones/cellZone/cellZone.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/faceZone/faceZone.C
+++ b/src/OpenFOAM/meshes/polyMesh/zones/faceZone/faceZone.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/faceZone/faceZone.H
+++ b/src/OpenFOAM/meshes/polyMesh/zones/faceZone/faceZone.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/pointZone/pointZone.C
+++ b/src/OpenFOAM/meshes/polyMesh/zones/pointZone/pointZone.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/polyMesh/zones/pointZone/pointZone.H
+++ b/src/OpenFOAM/meshes/polyMesh/zones/pointZone/pointZone.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchTools.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchTools.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchTools.H
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchTools.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsCheck.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsCheck.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsEdgeOwner.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsEdgeOwner.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsSearch.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsSearch.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsSortEdges.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/PatchTools/PatchToolsSortEdges.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/primitiveMesh.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/primitiveMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/primitiveMesh/primitiveMesh.H
+++ b/src/OpenFOAM/meshes/primitiveMesh/primitiveMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/treeBoundBox/treeBoundBox.C
+++ b/src/OpenFOAM/meshes/treeBoundBox/treeBoundBox.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/treeBoundBox/treeBoundBox.H
+++ b/src/OpenFOAM/meshes/treeBoundBox/treeBoundBox.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/treeBoundBox/treeBoundBoxI.H
+++ b/src/OpenFOAM/meshes/treeBoundBox/treeBoundBoxI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/meshes/treeBoundBox/treeBoundBoxTemplates.C
+++ b/src/OpenFOAM/meshes/treeBoundBox/treeBoundBoxTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/Pair/Pair.H
+++ b/src/OpenFOAM/primitives/Pair/Pair.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/Switch/Switch.C
+++ b/src/OpenFOAM/primitives/bools/Switch/Switch.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/Switch/Switch.H
+++ b/src/OpenFOAM/primitives/bools/Switch/Switch.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/Switch/SwitchIO.C
+++ b/src/OpenFOAM/primitives/bools/Switch/SwitchIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/bool/bool.C
+++ b/src/OpenFOAM/primitives/bools/bool/bool.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/bool/bool.H
+++ b/src/OpenFOAM/primitives/bools/bool/bool.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/bools/bool/boolIO.C
+++ b/src/OpenFOAM/primitives/bools/bool/boolIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/chars/wchar/wchar.H
+++ b/src/OpenFOAM/primitives/chars/wchar/wchar.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/chars/wchar/wcharIO.C
+++ b/src/OpenFOAM/primitives/chars/wchar/wcharIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/functions/Polynomial/Polynomial.C
+++ b/src/OpenFOAM/primitives/functions/Polynomial/Polynomial.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/functions/Polynomial/Polynomial.H
+++ b/src/OpenFOAM/primitives/functions/Polynomial/Polynomial.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/functions/Polynomial/PolynomialIO.C
+++ b/src/OpenFOAM/primitives/functions/Polynomial/PolynomialIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/Hash/Hash.H
+++ b/src/OpenFOAM/primitives/hashes/Hash/Hash.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/Hasher/Hasher.C
+++ b/src/OpenFOAM/primitives/hashes/Hasher/Hasher.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/Hasher/Hasher.H
+++ b/src/OpenFOAM/primitives/hashes/Hasher/Hasher.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/Hasher/HasherInt.H
+++ b/src/OpenFOAM/primitives/hashes/Hasher/HasherInt.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1.C
+++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
+++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1Digest.C
+++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1Digest.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1Digest.H
+++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1Digest.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
+++ b/src/OpenFOAM/primitives/hashes/SHA1/SHA1I.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/nil/nil.H
+++ b/src/OpenFOAM/primitives/nil/nil.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRange.C
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRange.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRange.H
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRange.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRangeI.H
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRangeI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRanges.C
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRanges.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRanges.H
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRanges.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/labelRange/labelRangesI.H
+++ b/src/OpenFOAM/primitives/ranges/labelRange/labelRangesI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/ranges/scalarRange/scalarRange.C
+++ b/src/OpenFOAM/primitives/ranges/scalarRange/scalarRange.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/fileName/fileName.C
+++ b/src/OpenFOAM/primitives/strings/fileName/fileName.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/fileName/fileName.H
+++ b/src/OpenFOAM/primitives/strings/fileName/fileName.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/fileName/fileNameIO.C
+++ b/src/OpenFOAM/primitives/strings/fileName/fileNameIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/hashedWordList.C
+++ b/src/OpenFOAM/primitives/strings/lists/hashedWordList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/hashedWordList.H
+++ b/src/OpenFOAM/primitives/strings/lists/hashedWordList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/hashedWordListI.H
+++ b/src/OpenFOAM/primitives/strings/lists/hashedWordListI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/stringListOps.H
+++ b/src/OpenFOAM/primitives/strings/lists/stringListOps.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/stringListOpsTemplates.C
+++ b/src/OpenFOAM/primitives/strings/lists/stringListOpsTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/wordReList.H
+++ b/src/OpenFOAM/primitives/strings/lists/wordReList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/wordReListMatcher.H
+++ b/src/OpenFOAM/primitives/strings/lists/wordReListMatcher.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/lists/wordReListMatcherI.H
+++ b/src/OpenFOAM/primitives/strings/lists/wordReListMatcherI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/string/string.C
+++ b/src/OpenFOAM/primitives/strings/string/string.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/string/string.H
+++ b/src/OpenFOAM/primitives/strings/string/string.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/string/stringI.H
+++ b/src/OpenFOAM/primitives/strings/string/stringI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/stringOps/stringOps.C
+++ b/src/OpenFOAM/primitives/strings/stringOps/stringOps.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/stringOps/stringOps.H
+++ b/src/OpenFOAM/primitives/strings/stringOps/stringOps.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/word/word.H
+++ b/src/OpenFOAM/primitives/strings/word/word.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/word/wordI.H
+++ b/src/OpenFOAM/primitives/strings/word/wordI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/wordRe/wordRe.C
+++ b/src/OpenFOAM/primitives/strings/wordRe/wordRe.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/wordRe/wordRe.H
+++ b/src/OpenFOAM/primitives/strings/wordRe/wordRe.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/OpenFOAM/primitives/strings/wordRe/wordReI.H
+++ b/src/OpenFOAM/primitives/strings/wordRe/wordReI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/file/ensightFile.C
+++ b/src/conversion/ensight/file/ensightFile.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/file/ensightFile.H
+++ b/src/conversion/ensight/file/ensightFile.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/file/ensightGeoFile.C
+++ b/src/conversion/ensight/file/ensightGeoFile.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/file/ensightGeoFile.H
+++ b/src/conversion/ensight/file/ensightGeoFile.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPart.C
+++ b/src/conversion/ensight/part/ensightPart.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPart.H
+++ b/src/conversion/ensight/part/ensightPart.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartCells.C
+++ b/src/conversion/ensight/part/ensightPartCells.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartCells.H
+++ b/src/conversion/ensight/part/ensightPartCells.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartFaces.C
+++ b/src/conversion/ensight/part/ensightPartFaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartFaces.H
+++ b/src/conversion/ensight/part/ensightPartFaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartIO.C
+++ b/src/conversion/ensight/part/ensightPartIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartTemplates.C
+++ b/src/conversion/ensight/part/ensightPartTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightParts.C
+++ b/src/conversion/ensight/part/ensightParts.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightParts.H
+++ b/src/conversion/ensight/part/ensightParts.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/ensight/part/ensightPartsTemplates.C
+++ b/src/conversion/ensight/part/ensightPartsTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/calcPointCells.C
+++ b/src/conversion/meshReader/calcPointCells.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/createPolyBoundary.C
+++ b/src/conversion/meshReader/createPolyBoundary.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/createPolyCells.C
+++ b/src/conversion/meshReader/createPolyCells.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/meshReader.C
+++ b/src/conversion/meshReader/meshReader.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/meshReader.H
+++ b/src/conversion/meshReader/meshReader.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/meshReaderAux.C
+++ b/src/conversion/meshReader/meshReaderAux.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/starcd/STARCDMeshReader.C
+++ b/src/conversion/meshReader/starcd/STARCDMeshReader.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshReader/starcd/STARCDMeshReader.H
+++ b/src/conversion/meshReader/starcd/STARCDMeshReader.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshTables/boundaryRegion.C
+++ b/src/conversion/meshTables/boundaryRegion.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshTables/boundaryRegion.H
+++ b/src/conversion/meshTables/boundaryRegion.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshTables/cellTable.C
+++ b/src/conversion/meshTables/cellTable.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshTables/cellTable.H
+++ b/src/conversion/meshTables/cellTable.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshWriter/meshWriter.C
+++ b/src/conversion/meshWriter/meshWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshWriter/meshWriter.H
+++ b/src/conversion/meshWriter/meshWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshWriter/starcd/STARCDMeshWriter.C
+++ b/src/conversion/meshWriter/starcd/STARCDMeshWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/conversion/meshWriter/starcd/STARCDMeshWriter.H
+++ b/src/conversion/meshWriter/starcd/STARCDMeshWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/fileFormats/nas/NASCore.C
+++ b/src/fileFormats/nas/NASCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/fileFormats/nas/NASCore.H
+++ b/src/fileFormats/nas/NASCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/fileFormats/starcd/STARCDCore.C
+++ b/src/fileFormats/starcd/STARCDCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/fileFormats/starcd/STARCDCore.H
+++ b/src/fileFormats/starcd/STARCDCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/finiteVolume/fvMesh/fvMesh.C
+++ b/src/finiteVolume/fvMesh/fvMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/finiteVolume/fvMesh/fvMesh.H
+++ b/src/finiteVolume/fvMesh/fvMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/finiteVolume/interpolation/surfaceInterpolation/schemes/fixedBlended/fixedBlended.C
+++ b/src/finiteVolume/interpolation/surfaceInterpolation/schemes/fixedBlended/fixedBlended.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/finiteVolume/interpolation/surfaceInterpolation/schemes/fixedBlended/fixedBlended.H
+++ b/src/finiteVolume/interpolation/surfaceInterpolation/schemes/fixedBlended/fixedBlended.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/functionObjects/forces/forces/forces.C
+++ b/src/functionObjects/forces/forces/forces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/functionObjects/forces/forces/forces.H
+++ b/src/functionObjects/forces/forces/forces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blockEdges/splineEdge/CatmullRomSpline.C
+++ b/src/mesh/blockMesh/blockEdges/splineEdge/CatmullRomSpline.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blockEdges/splineEdge/CatmullRomSpline.H
+++ b/src/mesh/blockMesh/blockEdges/splineEdge/CatmullRomSpline.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blockEdges/splineEdge/splineEdge.C
+++ b/src/mesh/blockMesh/blockEdges/splineEdge/splineEdge.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blockEdges/splineEdge/splineEdge.H
+++ b/src/mesh/blockMesh/blockEdges/splineEdge/splineEdge.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blockMesh/blockMesh.C
+++ b/src/mesh/blockMesh/blockMesh/blockMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blocks/block/block.C
+++ b/src/mesh/blockMesh/blocks/block/block.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/mesh/blockMesh/blocks/block/block.H
+++ b/src/mesh/blockMesh/blocks/block/block.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateRotation/STARCDCoordinateRotation.C
+++ b/src/meshTools/coordinateSystems/coordinateRotation/STARCDCoordinateRotation.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateRotation/STARCDCoordinateRotation.H
+++ b/src/meshTools/coordinateSystems/coordinateRotation/STARCDCoordinateRotation.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateRotation/coordinateRotation.C
+++ b/src/meshTools/coordinateSystems/coordinateRotation/coordinateRotation.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateRotation/coordinateRotation.H
+++ b/src/meshTools/coordinateSystems/coordinateRotation/coordinateRotation.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateSystem.C
+++ b/src/meshTools/coordinateSystems/coordinateSystem.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateSystem.H
+++ b/src/meshTools/coordinateSystems/coordinateSystem.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateSystemNew.C
+++ b/src/meshTools/coordinateSystems/coordinateSystemNew.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateSystems.C
+++ b/src/meshTools/coordinateSystems/coordinateSystems.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/coordinateSystems.H
+++ b/src/meshTools/coordinateSystems/coordinateSystems.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/cylindricalCS.C
+++ b/src/meshTools/coordinateSystems/cylindricalCS.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/coordinateSystems/cylindricalCS.H
+++ b/src/meshTools/coordinateSystems/cylindricalCS.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMesh.C
+++ b/src/meshTools/edgeMesh/edgeMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMesh.H
+++ b/src/meshTools/edgeMesh/edgeMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/edgeMeshFormatsCore.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/edgeMeshFormatsCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/edgeMeshFormatsCore.H
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/edgeMeshFormatsCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormat.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormat.H
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormatRunTime.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/nas/NASedgeFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormat.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormat.H
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormatRunTime.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/obj/OBJedgeFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormat.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormat.H
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormatRunTime.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/starcd/STARCDedgeFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormat.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormat.H
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormatRunTime.C
+++ b/src/meshTools/edgeMesh/edgeMeshFormats/vtk/VTKedgeFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshI.H
+++ b/src/meshTools/edgeMesh/edgeMeshI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshIO.C
+++ b/src/meshTools/edgeMesh/edgeMeshIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/edgeMeshNew.C
+++ b/src/meshTools/edgeMesh/edgeMeshNew.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/featureEdgeMesh/featureEdgeMesh.C
+++ b/src/meshTools/edgeMesh/featureEdgeMesh/featureEdgeMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/meshTools/edgeMesh/featureEdgeMesh/featureEdgeMesh.H
+++ b/src/meshTools/edgeMesh/featureEdgeMesh/featureEdgeMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/cuttingPlane/cuttingPlane.C
+++ b/src/sampling/cuttingPlane/cuttingPlane.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/cuttingPlane/cuttingPlane.H
+++ b/src/sampling/cuttingPlane/cuttingPlane.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/cuttingPlane/cuttingPlaneTemplates.C
+++ b/src/sampling/cuttingPlane/cuttingPlaneTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/probes/probes.C
+++ b/src/sampling/probes/probes.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/probes/probes.H
+++ b/src/sampling/probes/probes.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/probes/probesGrouping.C
+++ b/src/sampling/probes/probesGrouping.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/probes/probesTemplates.C
+++ b/src/sampling/probes/probesTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSet/sampledSets/sampledSets.C
+++ b/src/sampling/sampledSet/sampledSets/sampledSets.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSet/sampledSets/sampledSets.H
+++ b/src/sampling/sampledSet/sampledSets/sampledSets.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSet/sampledSets/sampledSetsGrouping.C
+++ b/src/sampling/sampledSet/sampledSets/sampledSetsGrouping.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSet/sampledSets/sampledSetsTemplates.C
+++ b/src/sampling/sampledSet/sampledSets/sampledSetsTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/distanceSurface/distanceSurface.C
+++ b/src/sampling/sampledSurface/distanceSurface/distanceSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/distanceSurface/distanceSurface.H
+++ b/src/sampling/sampledSurface/distanceSurface/distanceSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/isoSurface/isoSurface.C
+++ b/src/sampling/sampledSurface/isoSurface/isoSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/isoSurface/sampledIsoSurface.C
+++ b/src/sampling/sampledSurface/isoSurface/sampledIsoSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/isoSurface/sampledIsoSurface.H
+++ b/src/sampling/sampledSurface/isoSurface/sampledIsoSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/isoSurface/sampledIsoSurfaceTemplates.C
+++ b/src/sampling/sampledSurface/isoSurface/sampledIsoSurfaceTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledCuttingPlane/sampledCuttingPlane.C
+++ b/src/sampling/sampledSurface/sampledCuttingPlane/sampledCuttingPlane.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledPatch/sampledPatch.C
+++ b/src/sampling/sampledSurface/sampledPatch/sampledPatch.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledPatch/sampledPatch.H
+++ b/src/sampling/sampledSurface/sampledPatch/sampledPatch.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledPlane/sampledPlane.C
+++ b/src/sampling/sampledSurface/sampledPlane/sampledPlane.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledPlane/sampledPlane.H
+++ b/src/sampling/sampledSurface/sampledPlane/sampledPlane.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurface/sampledSurface.C
+++ b/src/sampling/sampledSurface/sampledSurface/sampledSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurface/sampledSurface.H
+++ b/src/sampling/sampledSurface/sampledSurface/sampledSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurface/sampledSurfaceTemplates.C
+++ b/src/sampling/sampledSurface/sampledSurface/sampledSurfaceTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.C
+++ b/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.H
+++ b/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurfaces/sampledSurfacesGrouping.C
+++ b/src/sampling/sampledSurface/sampledSurfaces/sampledSurfacesGrouping.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/sampledSurfaces/sampledSurfacesTemplates.C
+++ b/src/sampling/sampledSurface/sampledSurfaces/sampledSurfacesTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFaces.C
+++ b/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFaces.H
+++ b/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFacesTemplates.C
+++ b/src/sampling/sampledSurface/thresholdCellFaces/sampledThresholdCellFacesTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/thresholdCellFaces/thresholdCellFaces.C
+++ b/src/sampling/sampledSurface/thresholdCellFaces/thresholdCellFaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/thresholdCellFaces/thresholdCellFaces.H
+++ b/src/sampling/sampledSurface/thresholdCellFaces/thresholdCellFaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/ensight/ensightSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/ensight/ensightSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/ensight/ensightSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/ensight/ensightSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/foam/foamSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/foam/foamSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/foam/foamSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/foam/foamSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/makeSurfaceWriterMethods.H
+++ b/src/sampling/sampledSurface/writers/makeSurfaceWriterMethods.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/none/noSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/none/noSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2019-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/none/noSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/none/noSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2019-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/proxy/proxySurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/proxy/proxySurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/proxy/proxySurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/proxy/proxySurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/raw/rawSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/raw/rawSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/raw/rawSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/raw/rawSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/starcd/starcdSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/starcd/starcdSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/starcd/starcdSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/starcd/starcdSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/surfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/surfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/surfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/surfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/vtk/vtkSurfaceWriter.C
+++ b/src/sampling/sampledSurface/writers/vtk/vtkSurfaceWriter.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/sampling/sampledSurface/writers/vtk/vtkSurfaceWriter.H
+++ b/src/sampling/sampledSurface/writers/vtk/vtkSurfaceWriter.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2011 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurface.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurface.H
+++ b/src/surfMesh/MeshedSurface/MeshedSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaceCore.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaceCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaceIO.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaceIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaceNew.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaceNew.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaceZones.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaceZones.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaces.C
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfaces.H
+++ b/src/surfMesh/MeshedSurface/MeshedSurfaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurface/MeshedSurfacesFwd.H
+++ b/src/surfMesh/MeshedSurface/MeshedSurfacesFwd.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurfaceAllocator/MeshedSurfaceIOAllocator.C
+++ b/src/surfMesh/MeshedSurfaceAllocator/MeshedSurfaceIOAllocator.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurfaceAllocator/MeshedSurfaceIOAllocator.H
+++ b/src/surfMesh/MeshedSurfaceAllocator/MeshedSurfaceIOAllocator.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxy.C
+++ b/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxy.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxy.H
+++ b/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxy.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxyCore.C
+++ b/src/surfMesh/MeshedSurfaceProxy/MeshedSurfaceProxyCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurface.C
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurface.H
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaceNew.C
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaceNew.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaces.C
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaces.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaces.H
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfaces.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfacesFwd.H
+++ b/src/surfMesh/UnsortedMeshedSurface/UnsortedMeshedSurfacesFwd.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfFields/surfFields.C
+++ b/src/surfMesh/surfFields/surfFields/surfFields.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfFields/surfFields.H
+++ b/src/surfMesh/surfFields/surfFields/surfFields.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfFields/surfFieldsFwd.H
+++ b/src/surfMesh/surfFields/surfFields/surfFieldsFwd.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfFields/surfGeoMesh.H
+++ b/src/surfMesh/surfFields/surfFields/surfGeoMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfPointFields/surfPointFields.C
+++ b/src/surfMesh/surfFields/surfPointFields/surfPointFields.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfPointFields/surfPointFields.H
+++ b/src/surfMesh/surfFields/surfPointFields/surfPointFields.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfPointFields/surfPointFieldsFwd.H
+++ b/src/surfMesh/surfFields/surfPointFields/surfPointFieldsFwd.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfFields/surfPointFields/surfPointGeoMesh.H
+++ b/src/surfMesh/surfFields/surfPointFields/surfPointGeoMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfMesh/surfMesh.C
+++ b/src/surfMesh/surfMesh/surfMesh.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfMesh/surfMesh.H
+++ b/src/surfMesh/surfMesh/surfMesh.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfMesh/surfMeshClear.C
+++ b/src/surfMesh/surfMesh/surfMeshClear.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfMesh/surfMeshIO.C
+++ b/src/surfMesh/surfMesh/surfMeshIO.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZone/surfZone.C
+++ b/src/surfMesh/surfZone/surfZone/surfZone.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZone/surfZone.H
+++ b/src/surfMesh/surfZone/surfZone/surfZone.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZone/surfZoneIOList.C
+++ b/src/surfMesh/surfZone/surfZone/surfZoneIOList.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZone/surfZoneIOList.H
+++ b/src/surfMesh/surfZone/surfZone/surfZoneIOList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZone/surfZoneList.H
+++ b/src/surfMesh/surfZone/surfZone/surfZoneList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifier.C
+++ b/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifier.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifier.H
+++ b/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifier.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifierList.H
+++ b/src/surfMesh/surfZone/surfZoneIdentifier/surfZoneIdentifierList.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCoreTemplates.C
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatCoreTemplates.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/ac3d/AC3DsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/gts/GTSsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/nas/NASsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/nas/NASsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/nas/NASsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/nas/NASsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/nas/NASsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/nas/NASsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/obj/OBJsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/off/OFFsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/off/OFFsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/off/OFFsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/off/OFFsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/off/OFFsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/off/OFFsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/ofs/OFSsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/smesh/SMESHsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/starcd/STARCDsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLpoint.H
+++ b/src/surfMesh/surfaceFormats/stl/STLpoint.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLtriangle.H
+++ b/src/surfMesh/surfaceFormats/stl/STLtriangle.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/stl/STLtriangleI.H
+++ b/src/surfMesh/surfaceFormats/stl/STLtriangleI.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/surfaceFormatsCore.C
+++ b/src/surfMesh/surfaceFormats/surfaceFormatsCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/surfaceFormatsCore.H
+++ b/src/surfMesh/surfaceFormats/surfaceFormatsCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/tri/TRIsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/vtk/VTKsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/wrl/WRLsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormat.C
+++ b/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormat.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormat.H
+++ b/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormat.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatCore.C
+++ b/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatCore.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatCore.H
+++ b/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatCore.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatRunTime.C
+++ b/src/surfMesh/surfaceFormats/x3d/X3DsurfaceFormatRunTime.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2009-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceRegistry/surfaceRegistry.C
+++ b/src/surfMesh/surfaceRegistry/surfaceRegistry.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/surfMesh/surfaceRegistry/surfaceRegistry.H
+++ b/src/surfMesh/surfaceRegistry/surfaceRegistry.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2010 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/triSurface/triSurface/interfaces/NAS/readNAS.C
+++ b/src/triSurface/triSurface/interfaces/NAS/readNAS.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+   Copyright (C) 2008 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/triSurface/triSurface/triSurface.C
+++ b/src/triSurface/triSurface/triSurface.C
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/src/triSurface/triSurface/triSurface.H
+++ b/src/triSurface/triSurface/triSurface.H
@@ -5,6 +5,8 @@
     \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
+    Copyright (C) 2008-2009 Mark Olesen
+-------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
 

--- a/wmake/wclean
+++ b/wmake/wclean
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wcleanLnIncludeAll
+++ b/wmake/wcleanLnIncludeAll
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wmake
+++ b/wmake/wmake
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2019 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wmakeCheckPwd
+++ b/wmake/wmakeCheckPwd
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2009 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wmakeLnInclude
+++ b/wmake/wmakeLnInclude
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2020 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-2011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wmakeLnIncludeAll
+++ b/wmake/wmakeLnIncludeAll
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2009-2010 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #

--- a/wmake/wmakePrintBuild
+++ b/wmake/wmakePrintBuild
@@ -6,6 +6,8 @@
 #   \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
+#     Copyright (C) 2008-1011 Mark Olesen
+#------------------------------------------------------------------------------
 # License
 #     This file is part of OpenFOAM.
 #


### PR DESCRIPTION
Adjusted in accordance with the author's rights as stipulated by the
German Act on Copyright and Related Rights (Urheberrechtsgesetz),
where the code was authored.

As section 13 of the Urheberrechtsgesetz states:

> The author has the right to be identified as the author of the work.
> He may determine whether the work shall bear a designation of
> authorship and which designation is to be used.

Copyright and authorship rights are non-transferrable under
Section 29(1), and the author furthermore certifies never to have
entered into a Contributor Agreement or equivalent with any parties
associated with OpenFOAM or otherwise relinquished the right to
assert authorship rights.