### PR TITLE
Update alphaEqn.H

### DIFF
--- a/src/twoPhaseModels/twoPhaseMixture/VoF/alphaEqn.H
+++ b/src/twoPhaseModels/twoPhaseMixture/VoF/alphaEqn.H
@@ -184,9 +184,9 @@
             );
         }
 
-        alpha2 = 1.0 - alpha1;
-
         mixture.correct();
+        
+        alpha2 = 1.0 - alpha1;
     }
 
     if (alphaApplyPrevCorr && MULESCorr)


### PR DESCRIPTION
alpha2 should be calculated after alpha1 was corrected by mixture.correct(). No changes will be done to alpha2 otherwise.