### PR TITLE
kOmegaSSTLM: edited delta to avoid floating point exception

### DIFF
--- a/src/MomentumTransportModels/momentumTransportModels/RAS/kOmegaSSTLM/kOmegaSSTLM.C
+++ b/src/MomentumTransportModels/momentumTransportModels/RAS/kOmegaSSTLM/kOmegaSSTLM.C
@@ -82,7 +82,7 @@ tmp<volScalarField::Internal> kOmegaSSTLM<BasicMomentumTransportModel>::Fthetat
     const volScalarField::Internal& omega = this->omega_();
     const volScalarField::Internal& y = this->y_();
 
-    const volScalarField::Internal delta(375*Omega*nu*ReThetat_()*y/sqr(Us));
+    const volScalarField::Internal delta(375*max(Omega, dimensionedScalar("omegaSmall", dimless/dimTime, small))*nu*ReThetat_()*y/sqr(Us));
     const volScalarField::Internal ReOmega(sqr(y)*omega/nu);
     const volScalarField::Internal Fwake(exp(-sqr(ReOmega/1e5)));
 


### PR DESCRIPTION
In some cases (e.g. airfoil with non zero AoA), floating point exception occurs due to zero values in delta of kOmegaSSTLM.
added max function to the Omega part of delta such that delta will change zero values into a small value.