### PR TITLE
 externalWallHeatFluxTemperature BC fix when Q is provided

### DIFF
--- a/src/ThermophysicalTransportModels/derivedFvPatchFields/externalWallHeatFluxTemperature/externalWallHeatFluxTemperatureFvPatchScalarField.C
+++ b/src/ThermophysicalTransportModels/derivedFvPatchFields/externalWallHeatFluxTemperature/externalWallHeatFluxTemperatureFvPatchScalarField.C
@@ -277,7 +277,7 @@ void Foam::externalWallHeatFluxTemperatureFvPatchScalarField::updateCoeffs()
     scalarField qTot(qr);
     if (haveQ_)
     {
-        qTot += Q_;
+        qTot += Q_ / gSum(patch().magSf());
     }
     if (haveq_)
     {


### PR DESCRIPTION
Fix in externalWallHeatFluxTemperature boundary condition: added division by patch area in total heat flux calculation when boundary condition is provided by using power Q.