### PR TITLE
Fix various typos

### DIFF
--- a/applications/solvers/combustion/XiFoam/XiFoam.C
+++ b/applications/solvers/combustion/XiFoam/XiFoam.C
@@ -35,7 +35,7 @@ Description
     to be appropriate by comparison with the results from the
     spectral model.
 
-    Strain effects are encorporated directly into the Xi equation
+    Strain effects are incorporated directly into the Xi equation
     but not in the algebraic approximation.  Further work need to be
     done on this issue, particularly regarding the enhanced removal rate
     caused by flame compression.  Analysis using results of the spectral

--- a/applications/solvers/multiphase/driftFluxFoam/mixtureViscosityModels/Quemada/Quemada.H
+++ b/applications/solvers/multiphase/driftFluxFoam/mixtureViscosityModels/Quemada/Quemada.H
@@ -25,7 +25,7 @@ Class
     Foam::mixtureViscosityModels::Quemada
 
 Description
-     Quemada viscosity model for for colloidal dispersions.
+     Quemada viscosity model for colloidal dispersions.
 
      References:
      \verbatim

--- a/applications/solvers/multiphase/multiphaseEulerFoam/phaseSystems/PhaseSystems/HeatTransferPhaseSystem/HeatTransferPhaseSystem.H
+++ b/applications/solvers/multiphase/multiphaseEulerFoam/phaseSystems/PhaseSystems/HeatTransferPhaseSystem/HeatTransferPhaseSystem.H
@@ -163,7 +163,7 @@ public:
     // Member Functions
 
         //- Return the latent heat for a given interface, mass transfer rate
-        //  (used only for it's sign), and interface temperature
+        //  (used only for its sign), and interface temperature
         virtual tmp<volScalarField> L
         (
             const phaseInterface& interface,
@@ -183,7 +183,7 @@ public:
         ) const;
 
         //- Return the latent heat for a given interface, specie, mass transfer
-        //  rate (used only for it's sign), and interface temperature
+        //  rate (used only for its sign), and interface temperature
         virtual tmp<volScalarField> Li
         (
             const phaseInterface& interface,

--- a/applications/solvers/multiphase/multiphaseEulerFoam/phaseSystems/PhaseSystems/HeatTransferPhaseSystem/heatTransferPhaseSystem.H
+++ b/applications/solvers/multiphase/multiphaseEulerFoam/phaseSystems/PhaseSystems/HeatTransferPhaseSystem/heatTransferPhaseSystem.H
@@ -79,7 +79,7 @@ public:
     // Member Functions
 
         //- Return the latent heat for a given interface, mass transfer rate
-        //  (used only for it's sign), and interface temperature
+        //  (used only for its sign), and interface temperature
         virtual tmp<volScalarField> L
         (
             const phaseInterface& interface,
@@ -99,7 +99,7 @@ public:
         ) const = 0;
 
         //- Return the latent heat for a given interface, specie, mass transfer
-        //  rate (used only for it's sign), and interface temperature
+        //  rate (used only for its sign), and interface temperature
         virtual tmp<volScalarField> Li
         (
             const phaseInterface& interface,

--- a/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/CV2D.C
+++ b/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/CV2D.C
@@ -820,7 +820,7 @@ void Foam::CV2D::newPoints()
             } while (++ec != ecStart);
 
             // Initialise cd0 such that the mesh will align
-            // in in the x-y directions
+            // in the x-y directions
             vector2D cd0(1, 0);
 
             if (meshControls().relaxOrientation())

--- a/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/CV2D.H
+++ b/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/CV2D.H
@@ -198,14 +198,14 @@ class CV2D
 
     // Private Member Functions
 
-        //- Insert point and return it's index
+        //- Insert point and return its index
         inline label insertPoint
         (
             const point2D& pt,
             const label type
         );
 
-        //- Insert point and return it's index
+        //- Insert point and return its index
         inline label insertPoint
         (
             const point2D& pt,
@@ -288,7 +288,7 @@ class CV2D
         );
 
         //- Insert point-pair at the best intersection point between the lines
-        //  from the dual-cell real centroid and it's vertices and the surface.
+        //  from the dual-cell real centroid and its vertices and the surface.
         bool insertPointPairAtIntersection
         (
             Triangulation::Finite_vertices_iterator& vit,

--- a/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/insertBoundaryConformPointPairs.C
+++ b/applications/utilities/mesh/generation/foamyMesh/foamyQuadMesh/insertBoundaryConformPointPairs.C
@@ -250,7 +250,7 @@ Foam::label Foam::CV2D::insertBoundaryConformPointPairs
 
             // Check dimensions of dual-cell
             /*
-            // Quick rejection of dual-cell refinement based on it's perimeter
+            // Quick rejection of dual-cell refinement based on its perimeter
             if (perimeter < 2*meshControls().minCellSize()) continue;
 
             // Also check the area of the cell and reject refinement

--- a/applications/utilities/surface/surfaceCoarsen/bunnylod/progmesh.C
+++ b/applications/utilities/surface/surfaceCoarsen/bunnylod/progmesh.C
@@ -158,7 +158,7 @@ float ComputeEdgeCollapseCost(Vertex *u,Vertex *v) {
         // The method of determining cost was designed in order
         // to exploit small and coplanar regions for
         // effective polygon reduction.
-        // Is is possible to add some checks here to see if "folds"
+        // It is possible to add some checks here to see if "folds"
         // would be generated.  i.e. normal of a remaining face gets
         // flipped.  I never seemed to run into this problem and
         // therefore never added code to detect this case.

--- a/doc/Doxygen/README.html
+++ b/doc/Doxygen/README.html
@@ -176,7 +176,7 @@ permission for the directory that Doxygen writes files to.
 <h2 id="sec-2"><span class="section-number-2">2</span> Configuration</h2>
 <div class="outline-text-2" id="text-2">
 <p>
-The Doygen configuration file, Doxyfile, in the <code>$WM_PROJECT_DIR/doc/Doxygen</code>
+The Doxygen configuration file, Doxyfile, in the <code>$WM_PROJECT_DIR/doc/Doxygen</code>
 directory is configured to work with Doxygen versions 1.6.3-1.8.5.
 </p>
 

--- a/doc/Doxygen/README.org
+++ b/doc/Doxygen/README.org
@@ -22,7 +22,7 @@
   permission for the directory that Doxygen writes files to.
 
 * Configuration
-  The Doygen configuration file, Doxyfile, in the =$WM_PROJECT_DIR/doc/Doxygen=
+  The Doxygen configuration file, Doxyfile, in the =$WM_PROJECT_DIR/doc/Doxygen=
   directory is configured to work with Doxygen versions 1.6.3-1.8.5.
 
   The Header, Footer, and Stylesheet are generated automatically:

--- a/etc/caseDicts/annotated/foamyHexMeshDict
+++ b/etc/caseDicts/annotated/foamyHexMeshDict
@@ -406,7 +406,7 @@ polyMeshFiltering
 
     // Maximum number of times an to allow an equal faceSet to be
     // returned from the face quality assessment before stopping iterations
-    // to break an infinitie loop.
+    // to break an infinite loop.
     maxConsecutiveEqualFaceSets             5;
     // Remove little steps (almost perp to surface) by collapsing face.
     surfaceStepFaceAngle                    80;

--- a/etc/caseDicts/annotated/topoSetDict
+++ b/etc/caseDicts/annotated/topoSetDict
@@ -128,7 +128,7 @@ set p0;
 option any;         // cell with any point in pointSet
 // option edge;      // cell with an edge with both points in pointSet
 
-// cellSet baed on shape of cells
+// cellSet based on shape of cells
 source shapeToCell;
 type hex;           // hex/wedge/prism/pyr/tet/tetWedge/splitHex
 

--- a/etc/thermoData/therm.dat
+++ b/etc/thermoData/therm.dat
@@ -9,7 +9,7 @@ Contact: Elke.Goos@dlr.de
 *WARNING***The original 7-coeficient polynomials can accept molecules
 containing only four different elements. The new CHEMKIN program was changed to
 accept polynomials with 5 different elements. See the CHEMKIN manual.
-Where the fifth element exist, the new Chemkin convention was folowed.
+Where the fifth element exist, the new Chemkin convention was followed.
 
 THERMO ALL
    200.000  1000.000  6000.000

--- a/etc/thermoData/thermoData
+++ b/etc/thermoData/thermoData
@@ -10,7 +10,7 @@ Contact: Elke.Goos@dlr.de
 *WARNING***The original 7-coeficient polynomials can accept molecules
 containing only four different elements. The new CHEMKIN program was changed to
 accept polynomials with 5 different elements. See the CHEMKIN manual.
-Where the fifth element exist, the new Chemkin convention was folowed.
+Where the fifth element exist, the new Chemkin convention was followed.
 
 This file was generated from therm.dat provided in this directory.
 Specie names have been transposed into a form supported by the OpenFOAM parser:

--- a/src/MomentumTransportModels/incompressible/RAS/LienCubicKE/LienCubicKE.H
+++ b/src/MomentumTransportModels/incompressible/RAS/LienCubicKE/LienCubicKE.H
@@ -206,7 +206,7 @@ public:
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 } // End namespace RASModels
-} // Edn namespace incompressible
+} // End namespace incompressible
 } // End namespace Foam
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/OpenFOAM/containers/LinkedLists/linkTypes/DLListBase/DLListBase.H
+++ b/src/OpenFOAM/containers/LinkedLists/linkTypes/DLListBase/DLListBase.H
@@ -77,7 +77,7 @@ private:
        //- first_ points to first element and last_ points to last element.
        link *first_, *last_;
 
-       //- Number of elements in in list
+       //- Number of elements in list
        label nElmts_;
 
 

--- a/src/OpenFOAM/containers/LinkedLists/linkTypes/SLListBase/SLListBase.H
+++ b/src/OpenFOAM/containers/LinkedLists/linkTypes/SLListBase/SLListBase.H
@@ -75,7 +75,7 @@ private:
        //  last_->next_ points to first element, i.e. circular storage
        link* last_;
 
-       //- Number of elements in in list
+       //- Number of elements in list
        label nElmts_;
 
 

--- a/src/OpenFOAM/db/error/messageStream.H
+++ b/src/OpenFOAM/db/error/messageStream.H
@@ -28,7 +28,7 @@ Description
     Class to handle messaging in a simple, consistent stream-based
     manner.
 
-    The messageStream class is globaly instantiated with a title string a
+    The messageStream class is globally instantiated with a title string a
     given severity, which controls the program termination, and a number of
     errors before termination.  Errors, messages and other data are piped to
     the messageStream class in the standard manner.

--- a/src/OpenFOAM/fields/pointPatchFields/pointPatchField/pointConstraint/pointConstraintI.H
+++ b/src/OpenFOAM/fields/pointPatchFields/pointPatchField/pointConstraint/pointConstraintI.H
@@ -84,7 +84,7 @@ inline void Foam::pointConstraint::combine(const pointConstraint& pc)
     {
         // Save single normal
         vector n = second();
-        // Apply to supplied point constaint
+        // Apply to supplied point constraint
         operator=(pc);
         applyConstraint(n);
     }

--- a/src/OpenFOAM/meshes/polyMesh/globalMeshData/globalMeshData.C
+++ b/src/OpenFOAM/meshes/polyMesh/globalMeshData/globalMeshData.C
@@ -2521,7 +2521,7 @@ Foam::autoPtr<Foam::globalIndex> Foam::globalMeshData::mergePoints
         // Send back
         pointSlavesMap.reverseDistribute(cpp.nPoints(), masterToGlobal);
 
-        // On slave copy master index into overal map.
+        // On slave copy master index into overall map.
         forAll(pointSlaves, pointi)
         {
             label meshPointi = cpp.meshPoints()[pointi];

--- a/src/OpenFOAM/meshes/polyMesh/polyMesh.H
+++ b/src/OpenFOAM/meshes/polyMesh/polyMesh.H
@@ -407,7 +407,7 @@ public:
             fileName meshDir() const;
 
             //- Return the current instance directory for points
-            //  Used in the construction of gemometric mesh data dependent
+            //  Used in the construction of geometric mesh data dependent
             //  on points
             const fileName& pointsInstance() const;
 

--- a/src/OpenFOAM/meshes/polyMesh/polyPatches/basic/coupled/coupledPolyPatch.C
+++ b/src/OpenFOAM/meshes/polyMesh/polyPatches/basic/coupled/coupledPolyPatch.C
@@ -358,25 +358,25 @@ bool Foam::coupledPolyPatch::order
             if (pp.size() != ownerNFaces)
             {
                 SeriousErrorInFunction<< "The patch " << name() << " has "
-                    << pp.size() << " faces whilst it's neighbour has "
+                    << pp.size() << " faces whilst its neighbour has "
                     << ownerNFaces << endl;
             }
             if (pp.nPoints() != ownerNPoints)
             {
                 SeriousErrorInFunction<< "The patch " << name() << " has "
-                    << pp.nPoints() << " points whilst it's neighbour has "
+                    << pp.nPoints() << " points whilst its neighbour has "
                     << ownerNPoints << endl;
             }
             if (pp.nEdges() != ownerNEdges)
             {
                 SeriousErrorInFunction<< "The patch " << name() << " has "
-                    << pp.nEdges() << " edges whilst it's neighbour has "
+                    << pp.nEdges() << " edges whilst its neighbour has "
                     << ownerNEdges << endl;
             }
             if (pp.nInternalEdges() != ownerNInternalEdges)
             {
                 SeriousErrorInFunction<< "The patch " << name() << " has "
-                    << pp.nInternalEdges() << " internal edges whilst it's "
+                    << pp.nInternalEdges() << " internal edges whilst its "
                     << "neighbour has " << ownerNInternalEdges << endl;
             }
         }

--- a/src/OpenFOAM/primitives/hashes/Hasher/Hasher.C
+++ b/src/OpenFOAM/primitives/hashes/Hasher/Hasher.C
@@ -46,7 +46,7 @@ Description
 // the public domain.  It has no warranty.
 //
 // You probably want to use hashlittle().  hashlittle() and hashbig()
-// hash byte arrays.  hashlittle() is is faster than hashbig() on
+// hash byte arrays.  hashlittle() is faster than hashbig() on
 // little-endian machines.  Intel and AMD are little-endian machines.
 // On second thought, you probably want hashlittle2(), which is identical to
 // hashlittle() except it returns two 32-bit hashes for the price of one.

--- a/src/ThermophysicalTransportModels/derivedFvPatchFields/externalCoupledTemperatureMixed/externalCoupledTemperatureMixedFvPatchScalarField.H
+++ b/src/ThermophysicalTransportModels/derivedFvPatchFields/externalCoupledTemperatureMixed/externalCoupledTemperatureMixedFvPatchScalarField.H
@@ -38,7 +38,7 @@ Description
         <magSfN> <valueN> <qDotN> <htcN>
     \endverbatim
 
-    and received as the constitutent pieces of the `mixed' condition, i.e.
+    and received as the constituent pieces of the `mixed' condition, i.e.
 
     \verbatim
         # Patch: <patch name>

--- a/src/dynamicMesh/polyTopoChange/polyTopoChange/removePoints.C
+++ b/src/dynamicMesh/polyTopoChange/polyTopoChange/removePoints.C
@@ -688,7 +688,7 @@ void Foam::removePoints::getUnrefimentSet
         // So now if any of the points-to-restore is used by any coupled face
         // anywhere the corresponding index in faceVertexRestore will be set.
 
-        // Now combine the localPointSet and the (sychronised)
+        // Now combine the localPointSet and the (synchronised)
         // boundary-points-to-restore.
 
         forAll(savedFaces_, saveI)

--- a/src/finiteVolume/cfdTools/general/porosityModel/DarcyForchheimer/DarcyForchheimer.H
+++ b/src/finiteVolume/cfdTools/general/porosityModel/DarcyForchheimer/DarcyForchheimer.H
@@ -72,10 +72,10 @@ class DarcyForchheimer
 {
     // Private Data
 
-        //- Darcy coeffient XYZ components (user-supplied) [1/m^2]
+        //- Darcy coefficient XYZ components (user-supplied) [1/m^2]
         dimensionedVector dXYZ_;
 
-        //- Forchheimer coeffient XYZ components (user-supplied) [1/m]
+        //- Forchheimer coefficient XYZ components (user-supplied) [1/m]
         dimensionedVector fXYZ_;
 
         //- Darcy coefficient - converted from dXYZ [1/m^2]

--- a/src/finiteVolume/fvMesh/fvPatches/fvPatch/fvPatch.H
+++ b/src/finiteVolume/fvMesh/fvPatches/fvPatch/fvPatch.H
@@ -226,9 +226,9 @@ public:
             //- Return patch weighting factors
             const scalarField& weights() const;
 
-            //- Return the face - cell distance coeffient
+            //- Return the face - cell distance coefficient
             //  except for coupled patches for which the cell-centre
-            //  to coupled-cell-centre distance coeffient is returned
+            //  to coupled-cell-centre distance coefficient is returned
             const scalarField& deltaCoeffs() const;
 
 

--- a/src/functionObjects/field/comfort/comfort.H
+++ b/src/functionObjects/field/comfort/comfort.H
@@ -132,7 +132,7 @@ class comfort
         //- Maximum number of correctors for cloth temperature
         int maxClothIter_;
 
-        //- Switch to use volume weighted velocity field for caluclation
+        //- Switch to use volume weighted velocity field for calculation
         Switch meanVelocity_;
 
 

--- a/src/functionObjects/field/streamlines/streamlinesParticle.C
+++ b/src/functionObjects/field/streamlines/streamlinesParticle.C
@@ -285,7 +285,7 @@ bool Foam::streamlinesParticle::move
     {
         if (lifeTime_ == 0)
         {
-            // Failure exit. Particle stagnated or it's life ran out.
+            // Failure exit. Particle stagnated or its life ran out.
             if (debug)
             {
                 Pout<< "streamlinesParticle: Removing stagnant particle:"

--- a/src/functionObjects/field/wallHeatTransferCoeff/wallHeatTransferCoeffModels/kappaEff/kappaEff.H
+++ b/src/functionObjects/field/wallHeatTransferCoeff/wallHeatTransferCoeffModels/kappaEff/kappaEff.H
@@ -26,7 +26,7 @@ Class
 
 Description
     Calculates the estimated flow heat transfer coefficient at wall patches
-    as the volScalarField field 'kappaEff' using one of equeations bellow.
+    as the volScalarField field 'kappaEff' using one of equations below.
 
     kappaEff model, given by:
 

--- a/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
+++ b/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
@@ -109,7 +109,7 @@ private:
             const bPatch& patchLevel
         );
 
-        //- Combine leves
+        //- Combine levels
         void combineLevels(const label curLevel);
 
         //- Shrink the number of levels to that specified

--- a/src/fvMeshDistributors/loadBalancer/fvMeshDistributorsLoadBalancer.H
+++ b/src/fvMeshDistributors/loadBalancer/fvMeshDistributorsLoadBalancer.H
@@ -78,9 +78,9 @@ class loadBalancer
         cpuTime cpuTime_;
 
         //- Enable multi-constraint load-balancing in which separate weights
-        //  are provided to the distrubutor for each of the CPU loads.
+        //  are provided to the distributor for each of the CPU loads.
         //  When disabled the CPU loads are summed and a single weight per cell
-        //  is provided to the distrubutor.
+        //  is provided to the distributor.
         //  Defaults to true.
         Switch multiConstraint_;
 

--- a/src/lagrangian/distributionModels/massRosinRammler/massRosinRammler.H
+++ b/src/lagrangian/distributionModels/massRosinRammler/massRosinRammler.H
@@ -28,7 +28,7 @@ Description
     Mass-based Rosin-Rammler distributionModel.
 
     Corrected form of the Rosin-Rammler distribution taking into account the
-    varying number of particles per parcel for for fixed-mass parcels.  This
+    varying number of particles per parcel for fixed-mass parcels.  This
     distribution should be used when
     \verbatim
         parcelBasisType mass;

--- a/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/PairModel/PairSpringSliderDashpot/PairSpringSliderDashpot.H
+++ b/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/PairModel/PairSpringSliderDashpot/PairSpringSliderDashpot.H
@@ -86,7 +86,7 @@ class PairSpringSliderDashpot
         //      parcelEquivD = cbrt(volumeFactor*nParticles)*p.d()
         //  + When volumeFactor = 1, the particles are compressed
         //    together so that the equivalent volume of the parcel is
-        //    the sum of the constitutent particles
+        //    the sum of the constituent particles
         //  + When volumeFactor = 3*sqrt(2)/pi, the particles are
         //    close packed, but uncompressed.
         //  + When volumeFactor > 3*sqrt(2)/pi, the particles loosely

--- a/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/WallModel/WallLocalSpringSliderDashpot/WallLocalSpringSliderDashpot.H
+++ b/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/WallModel/WallLocalSpringSliderDashpot/WallLocalSpringSliderDashpot.H
@@ -89,7 +89,7 @@ class WallLocalSpringSliderDashpot
         //      parcelEquivD = cbrt(volumeFactor*nParticles)*p.d()
         //  + When volumeFactor = 1, the particles are compressed
         //    together so that the equivalent volume of the parcel is
-        //    the sum of the constitutent particles
+        //    the sum of the constituent particles
         //  + When volumeFactor = 3*sqrt(2)/pi, the particles are
         //    close packed, but uncompressed.
         //  + When volumeFactor > 3*sqrt(2)/pi, the particles loosely

--- a/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/WallModel/WallSpringSliderDashpot/WallSpringSliderDashpot.H
+++ b/src/lagrangian/parcel/submodels/Momentum/CollisionModel/PairCollision/WallModel/WallSpringSliderDashpot/WallSpringSliderDashpot.H
@@ -83,7 +83,7 @@ class WallSpringSliderDashpot
         //      parcelEquivD = cbrt(volumeFactor*nParticles)*p.d()
         //  + When volumeFactor = 1, the particles are compressed
         //    together so that the equivalent volume of the parcel is
-        //    the sum of the constitutent particles
+        //    the sum of the constituent particles
         //  + When volumeFactor = 3*sqrt(2)/pi, the particles are
         //    close packed, but uncompressed.
         //  + When volumeFactor > 3*sqrt(2)/pi, the particles loosely

--- a/src/mesh/snappyHexMesh/meshRefinement/meshRefinementRefine.C
+++ b/src/mesh/snappyHexMesh/meshRefinement/meshRefinementRefine.C
@@ -631,7 +631,7 @@ void Foam::meshRefinement::markFeatureCellLevel
     //        {
     //            Pout<< "Feature went through cell:" << celli
     //                << " coord:" << mesh_.cellCentres()[celli]
-    //                << " leve:" << maxFeatureLevel[celli]
+    //                << " level:" << maxFeatureLevel[celli]
     //                << endl;
     //        }
     //    }

--- a/src/meshTools/AMIInterpolation/AMIInterpolation/AMIMethod/sweptFaceAreaWeightAMI/sweptFaceAreaWeightAMI.H
+++ b/src/meshTools/AMIInterpolation/AMIInterpolation/AMIMethod/sweptFaceAreaWeightAMI/sweptFaceAreaWeightAMI.H
@@ -62,7 +62,7 @@ Description
 
     To calculate an intersection with a line between points \f$l_0\f$ to
     \f$l_1\f$, we define a local coordinate, \f$w\f$, along the line, and
-    subtract it's equation from that of the surface:
+    subtract its equation from that of the surface:
     \f[
         0 = (p_0 - l_0) - (l_1 - l_0) w + (p_1 - p_0) u +
             [ q_0 + (q_1 - q_0) u ] v

--- a/src/meshTools/patchToPatch/intersection/intersectionPatchToPatch.H
+++ b/src/meshTools/patchToPatch/intersection/intersectionPatchToPatch.H
@@ -207,7 +207,7 @@ private:
 
         // Geometry
 
-            //- The coupling geometry for for each source face
+            //- The coupling geometry for each source face
             List<DynamicList<couple>> srcCouples_;
 
             //- The non-coupled geometry associated with each source edge
@@ -217,7 +217,7 @@ private:
             //  source face's couplings
             List<part> srcErrorParts_;
 
-            //- The coupling geometry for for each target face
+            //- The coupling geometry for each target face
             List<DynamicList<couple>> tgtCouples_;
 
 

--- a/src/meshTools/searchableSurfaces/searchableSurfaceCollection/searchableSurfaceCollection.H
+++ b/src/meshTools/searchableSurfaces/searchableSurfaceCollection/searchableSurfaceCollection.H
@@ -36,7 +36,7 @@ Usage
     \c scale parameter and then rotated and translated by the mandatory
     \c transform.  In the example below, two geometries are included named
     \c buildingB and \c buildingC which are both formed by a translation
-    of \c buildingA according to the \c origin paramater. No rotation is
+    of \c buildingA according to the \c origin parameter. No rotation is
     applied (by setting e1 and e2 to the global x and y axis directions,
     respectively).
 

--- a/src/meshTools/triIntersect/triIntersect.C
+++ b/src/meshTools/triIntersect/triIntersect.C
@@ -77,7 +77,7 @@ Ostream& operator<<(Ostream& os, const FixedList<FixedList<Type, 3>, 3>& l)
 
 
 //- Clip the given vector between values of 0 and 1, and also clip one minus
-//  it's component sum. Clipping is applied to groups of components. It is done
+//  its component sum. Clipping is applied to groups of components. It is done
 //  by moving the value linearly towards the value where all components in the
 //  group, and one minus their sum, share the same value.
 vector clipped01(const vector x, const FixedList<label, 3> groups)

--- a/src/meshTools/triIntersect/triIntersect.H
+++ b/src/meshTools/triIntersect/triIntersect.H
@@ -24,7 +24,7 @@ License
 Description
     Functions with which to perform an intersection of a pair of triangles; the
     source and target. The source triangle is specified with three point
-    locations and three point normals. It is projected along it's point normals
+    locations and three point normals. It is projected along its point normals
     onto the target triangle in order to calculate the intersection. The target
     triangle is specified as three point locations only.
 

--- a/src/regionModels/thermalBaffleModels/derivedFvPatchFields/thermalBaffle/thermalBaffleFvPatchScalarField.C
+++ b/src/regionModels/thermalBaffleModels/derivedFvPatchFields/thermalBaffle/thermalBaffleFvPatchScalarField.C
@@ -94,7 +94,7 @@ void thermalBaffleFvPatchScalarField::checkPatches() const
     checkPatchMapsDifferentRegion(mpp);
     checkPatchMapsDifferentRegion(nbrMpp);
 
-    // The sample region of this patch and it's neighbour should be the same,
+    // The sample region of this patch and its neighbour should be the same,
     // i.e., that of the thermal baffle model
     if (mpp.sampleRegion() != nbrMpp.sampleRegion())
     {
@@ -109,7 +109,7 @@ void thermalBaffleFvPatchScalarField::checkPatches() const
             << exit(FatalError);
     }
 
-    // The sample patch of this patch and it's neighbour should be different,
+    // The sample patch of this patch and its neighbour should be different,
     // i.e., they should sample opposite ends of the thermal baffle mesh
     if (mpp.samplePatch() == nbrMpp.samplePatch())
     {

--- a/src/sampling/meshToMesh0/calculateMeshToMesh0Addressing.C
+++ b/src/sampling/meshToMesh0/calculateMeshToMesh0Addressing.C
@@ -268,7 +268,7 @@ void Foam::meshToMesh0::cellAddresses
         else
         {
             // If curCell is a boundary cell then the point maybe either outside
-            // the domain or in an other region of the doamin, either way use
+            // the domain or in an other region of the domain, either way use
             // the octree search to find it.
             if (boundaryCell[curCell])
             {

--- a/src/thermophysicalModels/chemistryModel/chemistryModel/chemistryModel.C
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/chemistryModel.C
@@ -478,7 +478,7 @@ Foam::chemistryModel<ThermoType>::tc() const
                 c_[i] = rhoi*Yvf_[i][celli]/specieThermos_[i].W();
             }
 
-            // A reaction's rate scale is calculated as it's molar
+            // A reaction's rate scale is calculated as its molar
             // production rate divided by the total number of moles in the
             // system.
             //

--- a/src/twoPhaseModels/twoPhaseMixture/MPLIC/MPLICcell.C
+++ b/src/twoPhaseModels/twoPhaseMixture/MPLIC/MPLICcell.C
@@ -253,7 +253,7 @@ Foam::FixedList<Foam::scalar, 4> Foam::MPLICcell::solveVanderMatrix() const
     //          [8/27 4/9 2/3 1]
     //          [1    1   1   1]
     //
-    // This means it's inverse can be precomputed. This pre-computation is hard
+    // This means its inverse can be precomputed. This pre-computation is hard
     // coded below.
 
     const vector4& b = cCubicAlphas_;

--- a/src/waves/waveSuperpositions/waveSuperposition/waveSuperposition.H
+++ b/src/waves/waveSuperpositions/waveSuperposition/waveSuperposition.H
@@ -26,7 +26,7 @@ Class
 
 Description
     A wrapper around a list of wave models. Superimposes the modelled values of
-    elevation and velocity. The New method looks up or or constructs an
+    elevation and velocity. The New method looks up or constructs an
     instance of this class on demand and returns a reference. Properties are
     read from a dictionary in constant.
 

--- a/wmake/wdep
+++ b/wmake/wdep
@@ -85,7 +85,7 @@ checkEnv
 
 
 #------------------------------------------------------------------------------
-# Check <file> is is the current directory,
+# Check if <file> is in the current directory,
 # otherwise search tree for first occurrence
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Most are misc. source comment typos but there are some doxygen and documentation related typos too.