### PR TITLE
added cstdint to be included in the primitives/string/word/word.C to …

### DIFF
--- a/src/OpenFOAM/primitives/strings/word/word.C
+++ b/src/OpenFOAM/primitives/strings/word/word.C
@@ -25,7 +25,7 @@ License
 
 #include "word.H"
 #include "debug.H"
-
+#include <cstdint>
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
 const char* const Foam::word::typeName = "word";


### PR DESCRIPTION
…fix compilation error on gcc where uintptr_t is undeclared in the scope